### PR TITLE
feat: Phase 1 v2 Amplop static shell (offline/seed)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,8 +1,12 @@
-# Review — PR #9: Phase 0 foundations for v2 Amplop (React + Vitest)
+# Review — PR #10: Phase 1 v2 Amplop static shell (offline/seed)
 
-First review. Scope: toolchain foundations only (React/Vite JSX, Vitest, canonical `fmtRp`).
-The vanilla app must keep building untouched; `proto/*.jsx` bundle absence is a known,
-accepted deferral (not a blocker).
+First review. Scope: port the handoff React prototype to ES modules and render the
+full interactive envelope-calendar UI against seed/localStorage only — no network,
+no live-app cutover. Reviewed at HEAD cc63596.
+
+Ratified decisions honored as not-bugs: stored `paid:{date,amount}` (no manual
+Langganan category), Import FAB stubbed ("segera hadir"), v2 mounts via new
+`v2.html` with `index.html` untouched, `fmtRp` absolute-value behaviour.
 
 ## Blocking
 
@@ -10,18 +14,34 @@ _None._
 
 ## Resolved
 
-_None yet._
+_None (first review, no prior blocking issues)._
 
 ## Non-blocking (nits)
 
-- `src/lib/format.js`: `fmtRp` relies on `toLocaleString('id-ID')` which depends on the
-  runtime having full ICU. Node 18+ ships full ICU by default (verified: ICU 78.3,
-  groups with dots), so this is fine today — worth a note if a minimal-ICU runtime is
-  ever targeted.
+- `src/components/ExpenseForm.jsx:23` and `src/components/PaySheet.jsx:17`:
+  `parseInt(amount, 10)` tolerates trailing garbage ("100abc" -> 100). Acceptable
+  for an `input[type=number]`, but a stricter parse would be marginally safer.
+- `src/app.jsx:50-63` `dayMinis`: days that fall in a shopping week owned by an
+  adjacent month (e.g. Mon 2026-06-29 -> July's week) get no "Sisa belanja" mini.
+  This is consistent with the engine's month-boundary attribution and is intended,
+  not a defect — noted only for awareness.
 
 ## Verification
 
-- `npm test` -> 7 passing (`src/lib/format.test.js`), includes failure path (NaN/Infinity/undefined -> `Rp0`).
-- `npm run build` -> vanilla app builds green with React plugin enabled.
-- Changed files limited to: package.json, package-lock.json, vite.config.js, src/lib/format.js, src/lib/format.test.js. No unrelated app code touched.
-- Conventional commit (`feat:`), single logical change.
+- `npm test` -> 27 passing (format 12, engine 12, app render smoke 3). Failure paths
+  covered: format.js non-finite -> Rp0/0; engine month-boundary (Fri/Sat ownership).
+- `npm run build` -> green; emits `dist/v2.html` + v2 bundle and an intact
+  `dist/index.html` (live vanilla app builds unchanged).
+- No live-app files touched (index.html, main.js, tabs/monthly/recap/modal/details,
+  style.css all unchanged). Focused diff.
+- No secrets, no network calls in new code (Phase 1 offline scope).
+- Form validation rejects non-positive/invalid amounts in ExpenseForm and PaySheet;
+  localStorage load/save both guarded with try/catch; non-finite guards in format.js.
+- Sheet routing (closeForm/closePay/openExpense) traced: from='day' returns to day
+  sheet, from='env' returns to langganan sheet, from=null closes fully — consistent.
+- UI copy is Indonesian; currency via shared `fmtK`/`fmtRp`; conventional `feat:` commit.
+
+## Blocking issues
+_None._
+
+VERDICT: READY_TO_MERGE

--- a/docs/v2-amplop-redesign-plan.md
+++ b/docs/v2-amplop-redesign-plan.md
@@ -88,18 +88,25 @@ weekendBudget  =   200,000   (per weekend in the month)
 flexBudget     = monthly − shopBudget − weekendBudget − subscriptionAlloc
 ```
 
-Subscription "paid" status is **derived**, not stored: a subscription counts as
-paid for a month if there's a `Langganan` expense with that `subscriptionId` in
-that month. The catalog (`SEED_SUBS`) is a pure reference table.
+Subscription "paid" status is **stored on the subscription**, not derived
+(corrected against the prototype during Phase 1 — the earlier "derived from a
+`Langganan` expense" description was inaccurate). Each subscription carries
+`paid: { date, amount } | null`; a "Bayar" sheet sets or clears it. A
+subscription counts as paid for a month when its `paid.date` falls in that
+month. Paid subscriptions also surface as synthetic `Langganan`-tagged rows in
+the day/history views. There is **no manual `Langganan` category** — the manual
+set is Makan / Belanja / Jajan / Cash / Lainnya.
 
 ### 2.3 Data model (prototype)
 
 ```js
+// Manual expense — note: NO 'Langganan' here (subscriptions are separate).
 expense = { id, date: 'YYYY-MM-DD', time: 'HH:MM', amount: <number>,
-            cat: 'Makan'|'Belanja'|'Jajan'|'Cash'|'Lainnya'|'Langganan',
-            note: <string>, subscriptionId?: <string> }
+            cat: 'Makan'|'Belanja'|'Jajan'|'Cash'|'Lainnya', note: <string> }
 
-subscription = { id, name, color, alloc: <number>, dueDay: 1..31, active: <bool> }
+// Subscription — 'paid' is STORED (see §2.2), 'due' is a full date.
+subscription = { id, name, color, alloc: <number>, due: 'YYYY-MM-DD',
+                 paid: { date: 'YYYY-MM-DD', amount: <number> } | null }
 ```
 
 Persistence in the prototype is **`localStorage`** under key
@@ -260,7 +267,8 @@ Backend `add` must accept `time`, `cat`, and `subscriptionId` (today it takes
 ### 7.2 Category taxonomy + migration
 
 v2 categories drive the envelope engine by exact name, so they must be the
-canonical set: **Makan, Belanja, Jajan, Cash, Lainnya, Langganan.**
+canonical set: **Makan, Belanja, Jajan, Cash, Lainnya.** (Langganan is *not* a
+manual category — subscription payments are a separate resource; see §2.2/§7.3.)
 
 Existing data uses different types. A migration/mapping is required, e.g.:
 
@@ -275,10 +283,11 @@ map at read-time.
 
 ### 7.3 Subscriptions
 
-New catalog resource: `{ id, name, color, alloc, dueDay, active }`. Needs
-read (and eventually CRUD) endpoints. "Paid this month" stays **derived** from
-`Langganan` expenses — do not store a `paid` flag (matches the prototype and
-its `migrateStore` logic).
+New catalog resource: `{ id, name, color, alloc, due, paid }` where
+`paid: { date, amount } | null` (see §2.2). Needs read (and eventually CRUD)
+endpoints, plus a way to set/clear a month's payment. "Paid this month" is
+**stored** on the subscription, not derived — corrected against the prototype
+in Phase 1.
 
 ### 7.4 Budget config
 

--- a/docs/v2-amplop-redesign-plan.md
+++ b/docs/v2-amplop-redesign-plan.md
@@ -306,14 +306,20 @@ endpoint) instead of the hard-coded `CFG`. Required for §5.2.
 - [x] Add React + Vite JSX support; set up a minimal test runner (Vitest) for
   the engine. First canonical helper `fmtRp` landed with success + failure-path
   tests.
-- [ ] Move v2 CSS into `styles/`, parameterized by `--accent` — **carried into
-  Phase 1**, blocked on the `proto/*.jsx` handoff bundle (not in this repo).
+- [x] Move v2 CSS into `styles/`, parameterized by `--accent` — done in Phase 1
+  (`styles/tokens.css` + `app.css`) once the handoff bundle was available.
 
-**Phase 1 — Static shell (offline / seed data)**
-- Port `expense-data` helpers, the engine, and all view components to ES modules.
-- Render top bar, envelope card, calendar, history, and all sheets against
-  **seed/localStorage data** (no network yet). Replace pinned `TODAY`.
-- Goal: pixel-faithful, fully interactive UI driven by local state.
+**Phase 1 — Static shell (offline / seed data)** ✅ *(done — PR #10)*
+- [x] Port `expense-data` helpers, the engine, and all view components to ES
+  modules (`src/lib/`, `src/components/`, `src/app.jsx`).
+- [x] Render top bar, envelope card, calendar, history, and all sheets against
+  **seed/localStorage data** (no network yet). Pinned `TODAY` replaced by an
+  injectable clock (`lib/today.js`).
+- [x] Goal met: interactive UI driven by local state, mounted via `v2.html`
+  (the live `index.html` stays until the Phase 3 cutover). Engine unit-tested
+  (attribution + month-boundary) + a jsdom render smoke test.
+- Note: built to the **prototype**, not the original §2.2/§7.3 text — those
+  sections were corrected (subscriptions store `paid`; no manual Langganan).
 
 **Phase 2 — Backend contract + wiring**
 - Define/adjust endpoints: `GET month` (raw expenses + subs + config),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,63 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^4.7.0",
+        "jsdom": "^29.1.1",
         "vite": "^5.0.0",
         "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -251,6 +304,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -297,6 +360,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -667,6 +883,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -984,6 +1218,63 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1169,6 +1460,42 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1190,6 +1517,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1291,6 +1628,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1309,6 +1674,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1319,12 +1691,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.378",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
       "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1425,11 +1829,82 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1486,6 +1961,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1495,6 +1981,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1529,6 +2022,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1582,6 +2088,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1607,10 +2139,28 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1654,6 +2204,19 @@
         "@rollup/rollup-win32-ia32-msvc": "4.45.1",
         "@rollup/rollup-win32-x64-msvc": "4.45.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -1705,6 +2268,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -1747,6 +2317,62 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.4.tgz",
+      "integrity": "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.4"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1928,6 +2554,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1944,6 +2618,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "^4.7.0",
+    "jsdom": "^29.1.1",
     "vite": "^5.0.0",
     "vitest": "^2.1.9"
   },

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,0 +1,184 @@
+// ============================================================
+// v2 Amplop — top-level app: state, month nav, sheet routing, persistence.
+// Ported from amplop-app.jsx. Changes from the prototype:
+//  - Tweaks panel dropped; entry style is fixed to the "menu" FAB flow.
+//  - Pinned TODAY replaced with the real clock (lib/today.js).
+//  - AI scan flow deferred to Phase 5; the menu's Import option is stubbed.
+//  - localStorage via data/store.js (Phase 2 swaps in the API).
+// ============================================================
+
+import { useEffect, useState } from 'react'
+import { MONTHS_ID, keyToDate } from './lib/dates.js'
+import { fmtK } from './lib/format.js'
+import { now, todayKey } from './lib/today.js'
+import { CFG, budgetConfig } from './lib/config.js'
+import { CATS, catColor, envColor, tagOf } from './lib/categories.js'
+import { computeAmplop } from './lib/amplop-engine.js'
+import { loadStore, saveStore, buildByDay } from './data/store.js'
+
+import { EnvelopeCard } from './components/EnvelopeCard.jsx'
+import { AmplopCalendar } from './components/AmplopCalendar.jsx'
+import { ListSection } from './components/ListSection.jsx'
+import { DaySheet } from './components/DaySheet.jsx'
+import { EnvelopeSheet } from './components/EnvelopeSheet.jsx'
+import { ExpenseForm } from './components/ExpenseForm.jsx'
+import { PaySheet } from './components/PaySheet.jsx'
+import { ScanEntryMenu } from './components/ScanEntryMenu.jsx'
+
+const TAG_STYLE = 'Garis samping'
+
+export function App() {
+  const [store, setStore] = useState(loadStore)
+  const [cursor, setCursor] = useState(() => ({ y: now().getFullYear(), m: now().getMonth() }))
+  const [sheet, setSheet] = useState(null)
+  const [filter, setFilter] = useState('Semua')
+
+  useEffect(() => { saveStore(store) }, [store])
+
+  const y = cursor.y, m = cursor.m
+  const cfg = budgetConfig()
+  const A = computeAmplop(store.expenses, store.subs, y, m, cfg)
+  const byDay = buildByDay(store.expenses, store.subs, A.monthPrefix)
+  const spentOf = (k) => (byDay[k] || []).reduce((s, e) => s + e.amount, 0)
+
+  const dayContext = (k) => {
+    const dow = keyToDate(k).getDay()
+    if (dow === 5) return 'Jumat · jatah belanja ' + fmtK(cfg.shopWeekly) + ' cair'
+    if (dow === 6 || dow === 0) return 'Akhir pekan · amplop ' + fmtK(cfg.weekendBudget) + ' (Sab–Min)'
+    return 'Hari kerja · amplop fleksibel'
+  }
+  const dayMinis = (k) => {
+    const total = spentOf(k)
+    const minis = [{ l: 'Terpakai', v: total > 0 ? fmtK(total) : '—' }]
+    const week = A.weeks.find((w) => k >= w.monK && k <= w.sunK)
+    if (week) minis.push({ l: 'Sisa belanja', v: fmtK(week.left), cls: week.left >= 0 ? 'g' : 'r' })
+    const dow = keyToDate(k).getDay()
+    if (dow === 0 || dow === 6) {
+      const wk = A.weekends.find((w) => k === w.satK || k === w.sunK)
+      if (wk) minis.push({ l: 'Sisa wknd', v: fmtK(wk.left), cls: wk.left >= 0 ? 'g' : 'r' })
+    } else {
+      minis.push({ l: 'Sisa fleksibel', v: fmtK(A.flexLeft), cls: A.flexLeft >= 0 ? 'g' : 'r' })
+    }
+    return minis
+  }
+
+  const isCurrentMonth = y === now().getFullYear() && m === now().getMonth()
+
+  // ---------- Actions ----------
+  function navMonth(delta) {
+    setCursor((c) => {
+      const d = new Date(c.y, c.m + delta, 1)
+      return { y: d.getFullYear(), m: d.getMonth() }
+    })
+  }
+  // FAB opens the entry menu (import / manual); a day cell goes straight to manual.
+  function openAdd(k, from) {
+    if (from !== 'day') {
+      setSheet({ type: 'menu', k: k || todayKey(), from: from || null })
+    } else {
+      setSheet({ type: 'form', k: k || todayKey(), exp: null, from: from || null })
+    }
+  }
+  function saveExpense(data) {
+    setStore((s) => {
+      if (data.id) {
+        return { ...s, expenses: s.expenses.map((e) => (e.id === data.id ? data : e)) }
+      }
+      return { ...s, expenses: s.expenses.concat([{ ...data, id: 'e' + Date.now() }]) }
+    })
+    closeForm()
+  }
+  function deleteExpense(id) {
+    setStore((s) => ({ ...s, expenses: s.expenses.filter((e) => e.id !== id) }))
+    closeForm()
+  }
+  function setSubPaid(id, paid) {
+    setStore((s) => ({ ...s, subs: s.subs.map((x) => (x.id === id ? { ...x, paid } : x)) }))
+    closePay()
+  }
+  function closeForm() {
+    setSheet((sh) => (sh && sh.from === 'day' ? { type: 'day', k: sh.k } : null))
+  }
+  function closePay() {
+    setSheet((sh) => {
+      if (sh && sh.from === 'env') return { type: 'env', which: 'langganan' }
+      if (sh && sh.from === 'day') return { type: 'day', k: sh.k }
+      return null
+    })
+  }
+  function openExpense(e, from, k) {
+    if (e.sub) { setSheet({ type: 'pay', subId: e.subId, from, k }); return }
+    setSheet({ type: 'form', k: e.date, exp: e, from })
+  }
+
+  // ---------- Render ----------
+  const cssVars = { '--accent': CFG.accent, '--cellH': CFG.cellH + 'px' }
+  const activeSub = sheet && sheet.type === 'pay'
+    ? store.subs.find((x) => x.id === sheet.subId)
+    : null
+
+  return (
+    <div className="app" style={cssVars} data-screen-label="Kalender Amplop v2">
+      <div className="topbar">
+        <div className="month-nav">
+          <button className="nav-btn" onClick={() => navMonth(-1)} aria-label="Bulan sebelumnya">‹</button>
+          <div className="month-center">
+            <div className="month-title">{MONTHS_ID[m]} {y}</div>
+          </div>
+          <button className="nav-btn" onClick={() => navMonth(1)} aria-label="Bulan selanjutnya">›</button>
+        </div>
+        {!isCurrentMonth ? (
+          <button className="today-pill" onClick={() => setCursor({ y: now().getFullYear(), m: now().getMonth() })}>
+            Kembali ke hari ini
+          </button>
+        ) : null}
+      </div>
+
+      <EnvelopeCard A={A} monthly={CFG.monthly} envColor={envColor}
+        onTapRow={(id) => setSheet({ type: 'env', which: id })} />
+
+      <AmplopCalendar y={y} m={m} spentOf={spentOf} cellH={CFG.cellH}
+        onDayTap={(k) => setSheet({ type: 'day', k })} />
+
+      <ListSection byDay={byDay} filter={filter} setFilter={setFilter} catColor={catColor}
+        cats={CATS.concat(['Langganan'])} tagOf={tagOf} tagStyle={TAG_STYLE}
+        onRowTap={(e) => openExpense(e, null, null)} />
+
+      <button className="fab" aria-label="Tambah pengeluaran hari ini"
+        onClick={() => openAdd(todayKey(), null)}>+</button>
+
+      {sheet && sheet.type === 'day' ? (
+        <DaySheet k={sheet.k} list={byDay[sheet.k] || []}
+          subLine={dayContext(sheet.k)} minis={dayMinis(sheet.k)} catColor={catColor}
+          tagOf={tagOf} tagStyle={TAG_STYLE}
+          onClose={() => setSheet(null)}
+          onAdd={() => openAdd(sheet.k, 'day')}
+          onEdit={(e) => openExpense(e, 'day', sheet.k)} />
+      ) : null}
+
+      {sheet && sheet.type === 'menu' ? (
+        <ScanEntryMenu
+          onManual={() => setSheet({ type: 'form', k: sheet.k, exp: null, from: sheet.from })}
+          onClose={() => setSheet((sh) => (sh && sh.from === 'day' ? { type: 'day', k: sh.k } : null))} />
+      ) : null}
+
+      {sheet && sheet.type === 'form' ? (
+        <ExpenseForm initial={sheet.exp} dateK={sheet.k} catColor={catColor}
+          onSave={saveExpense} onDelete={deleteExpense} onClose={closeForm} />
+      ) : null}
+
+      {sheet && sheet.type === 'env' ? (
+        <EnvelopeSheet which={sheet.which} A={A} cfg={cfg} subs={store.subs}
+          onTapSub={(sub) => setSheet({ type: 'pay', subId: sub.id, from: 'env' })}
+          onClose={() => setSheet(null)} />
+      ) : null}
+
+      {activeSub ? (
+        <PaySheet sub={activeSub} monthPrefix={A.monthPrefix}
+          onSave={(paid) => setSubPaid(activeSub.id, paid)}
+          onCancelPaid={() => setSubPaid(activeSub.id, null)}
+          onClose={closePay} />
+      ) : null}
+    </div>
+  )
+}

--- a/src/app.test.jsx
+++ b/src/app.test.jsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { App } from './app.jsx'
+import { setNow } from './lib/today.js'
+
+// Pin the clock to the seed month so the shell opens on data, deterministically.
+beforeEach(() => {
+  setNow(() => new Date(2026, 5, 25, 12, 0, 0))
+  if (typeof localStorage !== 'undefined') localStorage.clear()
+})
+afterEach(() => { setNow(null); cleanup() })
+
+describe('App — v2 shell mounts and renders', () => {
+  it('renders the current month title and envelope summary', () => {
+    render(<App />)
+    expect(screen.getByText('Juni 2026')).toBeTruthy()
+    expect(screen.getByText('Terpakai')).toBeTruthy()
+    expect(screen.getByText('Budget')).toBeTruthy()
+    expect(screen.getByText('Sisa')).toBeTruthy()
+  })
+
+  it('opens the entry menu from the FAB with a manual option', () => {
+    render(<App />)
+    fireEvent.click(screen.getByLabelText('Tambah pengeluaran hari ini'))
+    expect(screen.getByText('Input manual')).toBeTruthy()
+    // Import is present but stubbed (scan flow deferred to Phase 5).
+    expect(screen.getByText('Impor dari images')).toBeTruthy()
+  })
+
+  it('navigates months and shows the "back to today" pill', () => {
+    render(<App />)
+    fireEvent.click(screen.getByLabelText('Bulan sebelumnya'))
+    expect(screen.getByText('Mei 2026')).toBeTruthy()
+    expect(screen.getByText('Kembali ke hari ini')).toBeTruthy()
+  })
+})

--- a/src/components/AmplopCalendar.jsx
+++ b/src/components/AmplopCalendar.jsx
@@ -1,0 +1,47 @@
+// Month calendar grid (Monday-start). Each day cell shows the date and the
+// total spent that day; weekends tinted, today highlighted.
+// Ported from amplop-components.jsx (AmplopCell + AmplopCalendar).
+
+import { keyToDate, isWeekendKey, monthGrid, DOWS_HEAD } from '../lib/dates.js'
+import { fmtK } from '../lib/format.js'
+import { todayKey } from '../lib/today.js'
+
+function AmplopCell({ k, spent, cellH, onTap }) {
+  const day = keyToDate(k).getDate()
+  const isToday = k === todayKey()
+  let cls = 'cell'
+  if (isWeekendKey(k)) cls += ' wknd'
+  if (isToday) cls += ' today'
+  return (
+    <button className={cls} style={{ height: cellH }} onClick={onTap}>
+      <span className="dnum">{day}</span>
+      <span className="cellstack">
+        {spent > 0 ? <span className="spent">{fmtK(spent)}</span> : null}
+      </span>
+    </button>
+  )
+}
+
+export function AmplopCalendar({ y, m, spentOf, cellH, onDayTap }) {
+  const weeks = monthGrid(y, m)
+  return (
+    <div className="card cal-card">
+      <div className="cal-head">
+        {DOWS_HEAD.map((d, i) => (
+          <div key={d} className={'cal-dow' + (i >= 5 ? ' wk' : '')}>{d}</div>
+        ))}
+      </div>
+      {weeks.map((week, wi) => (
+        <div className="cal-row" key={wi}>
+          {week.map((k, ci) => {
+            if (!k) return <div className="cell empty" style={{ height: cellH }} key={'x' + ci}></div>
+            return (
+              <AmplopCell key={k} k={k} spent={spentOf(k)} cellH={cellH}
+                onTap={() => onDayTap(k)} />
+            )
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/DaySheet.jsx
+++ b/src/components/DaySheet.jsx
@@ -1,0 +1,33 @@
+// One day's expenses + mini-stats (terpakai / sisa belanja / sisa weekend or
+// flexible) + "Tambah Pengeluaran". Ported from amplop-components.jsx (DaySheetV2).
+
+import { Sheet } from './Sheet.jsx'
+import { ExpRow } from './ExpRow.jsx'
+import { fmtDateLong } from '../lib/format.js'
+
+export function DaySheet({ k, list, subLine, minis, catColor, tagOf, tagStyle, onClose, onAdd, onEdit }) {
+  return (
+    <Sheet onClose={onClose}>
+      <div className="sheet-title">{fmtDateLong(k)}</div>
+      <div className="sheet-sub">{subLine}</div>
+      <div className="mini-stats" style={{ gridTemplateColumns: 'repeat(' + minis.length + ', 1fr)' }}>
+        {minis.map((s, i) => (
+          <div className="mini" key={i}>
+            <div className="mini-l">{s.l}</div>
+            <div className={'mini-v' + (s.cls ? ' ' + s.cls : '')}>{s.v}</div>
+          </div>
+        ))}
+      </div>
+      <div className="sheet-list">
+        {list.length === 0 ? (
+          <div className="empty-note">Belum ada pengeluaran di hari ini</div>
+        ) : (
+          list.map((e) => (
+            <ExpRow key={e.id} e={e} catColor={catColor} tag={tagOf ? tagOf(e) : null} tagStyle={tagStyle} onClick={() => onEdit(e)} />
+          ))
+        )}
+      </div>
+      <button className="btn primary full" onClick={onAdd}>+ Tambah Pengeluaran</button>
+    </Sheet>
+  )
+}

--- a/src/components/EnvelopeCard.jsx
+++ b/src/components/EnvelopeCard.jsx
@@ -1,0 +1,54 @@
+// Envelope card (replaces the old stat strip). Collapsed: Terpakai/Budget/Sisa.
+// Expanded: the four envelope rows with progress bars.
+// Ported from amplop-components.jsx (EnvelopeCard).
+
+import { useState } from 'react'
+import { fmtK } from '../lib/format.js'
+
+export function EnvelopeCard({ A, monthly, envColor, onTapRow }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="card env-card">
+      <button className={'env-top env-toggle' + (open ? ' open' : '')} onClick={() => setOpen(!open)} aria-expanded={open}>
+        <div className="stat">
+          <div className="stat-label">Terpakai</div>
+          <div className="stat-value">{fmtK(A.totalSpent)}</div>
+        </div>
+        <div className="stat mid">
+          <div className="stat-label">Budget</div>
+          <div className="stat-value">{fmtK(monthly)}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-label">Sisa</div>
+          <div className={'stat-value ' + (A.sisa >= 0 ? 'g' : 'r')}>{fmtK(A.sisa)}</div>
+        </div>
+        <span className={'env-top-caret' + (open ? ' open' : '')}>›</span>
+      </button>
+      {open ? (
+        <div className="env-rows">
+          {A.rows.map((r) => {
+            const over = r.spent > r.budget
+            const pct = r.budget > 0 ? Math.min(100, (r.spent / r.budget) * 100) : 100
+            return (
+              <button className="env-row" key={r.id} onClick={() => onTapRow(r.id)}>
+                <span className="env-dot" style={{ background: envColor(r.id) }}></span>
+                <span className="env-main">
+                  <span className="env-line">
+                    <span className="env-label">{r.label}</span>
+                    <span className={'env-nums' + (over ? ' r' : '')}>
+                      {fmtK(r.spent)} <em>/ {fmtK(r.budget)}</em>
+                    </span>
+                  </span>
+                  <span className="bar">
+                    <span className="bar-fill" style={{ width: pct + '%', background: over ? 'var(--red)' : envColor(r.id) }}></span>
+                  </span>
+                </span>
+                <span className="env-caret">›</span>
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/EnvelopeSheet.jsx
+++ b/src/components/EnvelopeSheet.jsx
@@ -1,0 +1,130 @@
+// Per-envelope breakdown sheet (weeks, weekends, subscription list, or the
+// flexible math). Ported from amplop-components.jsx (WeekRow + EnvelopeSheet).
+
+import { Sheet } from './Sheet.jsx'
+import { fmtK, fmtDateShort } from '../lib/format.js'
+import { fmtRp } from '../lib/format.js'
+import { fmtRange } from '../lib/amplop-engine.js'
+import { todayKey } from '../lib/today.js'
+
+function WeekRow({ rangeText, w, startK }) {
+  const today = todayKey()
+  const past = w.sunK < today
+  const current = !past && startK <= today
+  return (
+    <div className="env-week">
+      <span className="ew-left">
+        <span className="ew-range">{rangeText}{current ? ' · pekan ini' : ''}</span>
+      </span>
+      <span className="ew-right">
+        {past ? (
+          <>
+            <span className="ew-amt">{fmtK(w.spent)} <em>/ {fmtK(w.budget)}</em></span>
+            {w.left === 0 ? (
+              <span className="diff pos">pas</span>
+            ) : (
+              <span className={'diff ' + (w.left > 0 ? 'pos' : 'neg')}>{w.left > 0 ? '+' : ''}{fmtK(w.left)}</span>
+            )}
+          </>
+        ) : current ? (
+          <>
+            <span className="ew-amt">{w.spent > 0 ? fmtK(w.spent) + ' terpakai' : 'belum ada'}</span>
+            <span className={'diff ' + (w.left >= 0 ? 'pos' : 'neg')}>sisa {fmtK(w.left)}</span>
+          </>
+        ) : (
+          <span className="ew-amt"><em>{fmtK(w.budget)}</em></span>
+        )}
+      </span>
+    </div>
+  )
+}
+
+export function EnvelopeSheet({ which, A, cfg, subs, onTapSub, onClose }) {
+  let title = '', sub = '', body = null, note = ''
+
+  if (which === 'belanja') {
+    title = 'Belanja Mingguan'
+    sub = 'Jatah ' + fmtK(cfg.shopWeekly) + ' cair tiap Jumat · berlaku Senin–Minggu pekan itu'
+    note = 'Mencakup Belanja & Cash (kapan saja), plus Makan & Jajan di hari kerja. Tiap pekan berdiri sendiri — pekan yang terpotong pergantian bulan ikut bulan dari hari Jumat-nya.'
+    body = (
+      <div className="env-list">
+        {A.weeks.map((w) => (
+          <WeekRow key={w.friK} rangeText={fmtRange(w.monK, w.sunK)} w={w} startK={w.monK} />
+        ))}
+      </div>
+    )
+  } else if (which === 'weekend') {
+    title = 'Akhir Pekan'
+    sub = fmtK(cfg.weekendBudget) + ' untuk Sabtu + Minggu (berdua)'
+    note = 'Mencakup Makan, Jajan & Lainnya di hari Sabtu–Minggu (Belanja & Cash tetap masuk Belanja Mingguan). Tiap akhir pekan berdiri sendiri — ikut bulan dari hari Sabtu-nya.'
+    body = (
+      <div className="env-list">
+        {A.weekends.map((w) => (
+          <WeekRow key={w.satK} rangeText={fmtRange(w.satK, w.sunK)} w={w} startK={w.satK} />
+        ))}
+      </div>
+    )
+  } else if (which === 'langganan') {
+    title = 'Langganan'
+    sub = fmtK(A.subsAlloc) + ' dialokasikan bulan ini'
+    body = (
+      <div className="sheet-list">
+        {subs.map((s) => {
+          const paid = s.paid && s.paid.date.indexOf(A.monthPrefix) === 0 ? s.paid : null
+          const diff = paid ? s.alloc - paid.amount : 0
+          return (
+            <button className="sub-row" key={s.id} onClick={() => onTapSub(s)}>
+              <span className="sub-main">
+                <span className="sub-name">{s.name}</span>
+                <span className="sub-sub">{paid ? '✓ Dibayar ' + fmtDateShort(paid.date) : 'Jatuh tempo ' + fmtDateShort(s.due)}</span>
+              </span>
+              <span className="sub-right">
+                <span className="sub-amt">{fmtRp(paid ? paid.amount : s.alloc)}</span>
+                {paid ? (
+                  diff !== 0
+                    ? <span className={'diff ' + (diff > 0 ? 'pos' : 'neg')}>{diff > 0 ? '+' : ''}{fmtK(diff)}</span>
+                    : <span className="diff pos">sesuai</span>
+                ) : (
+                  <span className="pay-tag">Bayar</span>
+                )}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    )
+  } else {
+    title = 'Fleksibel'
+    sub = 'Jatah yang tersisa setelah semua alokasi'
+    note = 'Hanya pengeluaran Lainnya di hari kerja yang dihitung dari amplop ini. Nilainya bisa minus kalau pemakaian melebihi jatah.'
+    const flexRows = [
+      { l: 'Budget bulanan', v: fmtK(cfg.monthly) },
+      { l: '− Belanja mingguan', v: '−' + fmtK(A.shopBudget) },
+      { l: '− Akhir pekan', v: '−' + fmtK(A.wkndBudget) },
+      { l: '− Langganan', v: '−' + fmtK(A.subsAlloc) },
+      { l: 'Jatah fleksibel', v: fmtK(A.flexBudget), strong: true },
+      { l: 'Terpakai', v: fmtK(A.flexSpent) },
+      { l: 'Sisa', v: fmtK(A.flexLeft), strong: true, cls: A.flexLeft >= 0 ? 'g' : 'r' },
+    ]
+    body = (
+      <div className="env-list">
+        {flexRows.map((r, i) => (
+          <div className={'fx-row' + (r.strong ? ' strong' : '') + (r.cls ? ' ' + r.cls : '')} key={i}>
+            <span className="fx-l">{r.l}</span>
+            <span className="fx-v">{r.v}</span>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <Sheet onClose={onClose}>
+      <div className="sheet-title">{title}</div>
+      <div className="sheet-sub">{sub}</div>
+      {body}
+      {note ? <div className="sheet-note">{note}</div> : null}
+      <button className="btn ghost full" onClick={onClose}>Tutup</button>
+    </Sheet>
+  )
+}

--- a/src/components/ExpRow.jsx
+++ b/src/components/ExpRow.jsx
@@ -1,0 +1,28 @@
+// One expense row, used in day sheets and the history list.
+// `tag` is the envelope tag from categories.tagOf; `tagStyle` 'Garis samping'
+// renders it as a coloured side bar. Ported from expense-components.jsx.
+
+import { fmtRp } from '../lib/format.js'
+
+export function ExpRow({ e, catColor, onClick, tag, tagStyle }) {
+  const bar = tag && tagStyle === 'Garis samping'
+  return (
+    <button className={'exp-row' + (bar ? ' has-bar' : '')} onClick={onClick}>
+      {bar ? <span className="amp-bar" style={{ background: tag.color }}></span> : null}
+      <span className="cat-dot" style={{ background: catColor(e.cat) }}></span>
+      <span className="exp-main">
+        <span className="exp-cat">
+          {e.cat}
+          {tag && !bar ? (
+            <span className="amp-tag" style={{ color: tag.color, background: 'color-mix(in srgb, ' + tag.color + ' 12%, white)' }}>{tag.label}</span>
+          ) : null}
+        </span>
+        {e.note ? <span className="exp-note">{e.note}</span> : null}
+      </span>
+      <span className="exp-right">
+        <span className="exp-amt">{fmtRp(e.amount)}</span>
+        {e.time ? <span className="exp-time">{e.time}</span> : null}
+      </span>
+    </button>
+  )
+}

--- a/src/components/ExpenseForm.jsx
+++ b/src/components/ExpenseForm.jsx
@@ -1,0 +1,86 @@
+// Add / edit expense form: amount, category chips, time, note.
+// Ported from expense-components.jsx (ExpenseForm). The scan banner only shows
+// when an onScan handler is supplied (deferred to Phase 5 — not wired here).
+
+import { useState } from 'react'
+import { Sheet } from './Sheet.jsx'
+import { CATS } from '../lib/categories.js'
+import { pad2 } from '../lib/dates.js'
+import { fmtDateLong } from '../lib/format.js'
+
+export function ExpenseForm({ initial, dateK, catColor, onSave, onDelete, onClose, onScan }) {
+  const [amount, setAmount] = useState(initial ? String(initial.amount) : '')
+  const [cat, setCat] = useState(initial ? initial.cat : 'Makan')
+  const [note, setNote] = useState(initial && initial.note ? initial.note : '')
+  const [time, setTime] = useState(() => {
+    if (initial && initial.time) return initial.time
+    const now = new Date()
+    return pad2(now.getHours()) + ':' + pad2(now.getMinutes())
+  })
+  const [err, setErr] = useState('')
+
+  function submit() {
+    const a = parseInt(amount, 10)
+    if (!a || a <= 0) { setErr('Masukkan jumlah yang valid'); return }
+    if (!time) { setErr('Waktu wajib diisi'); return }
+    onSave({ id: initial ? initial.id : null, date: dateK, time, amount: a, cat, note: note.trim() })
+  }
+
+  return (
+    <Sheet onClose={onClose}>
+      <div className="sheet-title">{initial ? 'Ubah Pengeluaran' : 'Tambah Pengeluaran'}</div>
+      <div className="sheet-sub">{fmtDateLong(dateK)}</div>
+      {onScan ? (
+        <button className="scan-banner" onClick={onScan}>
+          <span className="sb-ic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="5" y="2" width="14" height="20" rx="3" /><path d="M9 18h6" /><path d="m8.5 8.5 2.5 2.5 4-4.5" /></svg>
+          </span>
+          <span className="sb-tx">
+            <span className="sb-t">Impor dari images</span>
+            <span className="sb-s">Screenshot GoPay &amp; Livin’</span>
+          </span>
+          <span className="sb-go">›</span>
+        </button>
+      ) : null}
+      {err ? <div className="form-err">⚠️ {err}</div> : null}
+      <label className="f-label">Jumlah</label>
+      <div className="amt-wrap">
+        <span className="amt-rp">Rp</span>
+        <input className="amt-in" type="number" inputMode="numeric" step="500" placeholder="0"
+          value={amount} autoFocus={!initial}
+          onChange={(e) => { setAmount(e.target.value); setErr('') }} />
+      </div>
+      <label className="f-label">Kategori</label>
+      <div className="cat-chips">
+        {CATS.map((c) => {
+          const on = c === cat
+          return (
+            <button key={c} className={'chip' + (on ? ' on' : '')}
+              style={on ? { background: catColor(c) } : null}
+              onClick={() => setCat(c)}>
+              <span className="dot" style={{ background: on ? 'rgba(255,255,255,.85)' : catColor(c) }}></span>
+              {c}
+            </button>
+          )
+        })}
+      </div>
+      <div className="form-row">
+        <div className="form-col">
+          <label className="f-label">Waktu</label>
+          <input className="f-in" type="time" value={time} required lang="id-ID"
+            onChange={(e) => { setTime(e.target.value); setErr('') }} />
+        </div>
+      </div>
+      <label className="f-label">Catatan (opsional)</label>
+      <textarea className="f-in" rows="2" placeholder="Masukkan catatan pengeluaran..."
+        value={note} onChange={(e) => setNote(e.target.value)}></textarea>
+      <div className="btn-row">
+        {initial ? (
+          <button className="btn danger" onClick={() => onDelete(initial.id)}>Hapus</button>
+        ) : null}
+        <button className="btn ghost" onClick={onClose}>Batal</button>
+        <button className="btn primary" onClick={submit}>Simpan</button>
+      </div>
+    </Sheet>
+  )
+}

--- a/src/components/ListSection.jsx
+++ b/src/components/ListSection.jsx
@@ -1,0 +1,66 @@
+// Collapsible "Riwayat Pengeluaran" with category filter chips and expenses
+// grouped by day. Ported from expense-components.jsx (ListSection).
+
+import { useState } from 'react'
+import { ExpRow } from './ExpRow.jsx'
+import { CATS } from '../lib/categories.js'
+import { fmtRp, fmtDateLong } from '../lib/format.js'
+
+export function ListSection({ byDay, filter, setFilter, catColor, onRowTap, cats, tagOf, tagStyle }) {
+  const [open, setOpen] = useState(false)
+  const allCats = cats || CATS
+  const days = Object.keys(byDay).sort().reverse()
+  const groups = days.map((k) => {
+    const list = byDay[k].filter((e) => filter === 'Semua' || e.cat === filter)
+    return { k, list }
+  }).filter((g) => g.list.length > 0)
+  const txCount = days.reduce((s, k) => s + byDay[k].length, 0)
+
+  return (
+    <div className="list-section">
+      <button className="sec-head sec-toggle" onClick={() => setOpen(!open)} aria-expanded={open}>
+        <div className="sec-title">Riwayat Pengeluaran</div>
+        <div className="sec-meta">
+          {txCount} transaksi
+          <span className={'sec-caret' + (open ? ' open' : '')}>›</span>
+        </div>
+      </button>
+      {open ? (
+        <>
+          <div className="chips">
+            {['Semua'].concat(allCats).map((c) => {
+              const on = c === filter
+              const color = c === 'Semua' ? 'var(--accent)' : catColor(c)
+              return (
+                <button key={c} className={'chip' + (on ? ' on' : '')}
+                  style={on ? { background: color } : null}
+                  onClick={() => setFilter(c)}>
+                  {c !== 'Semua' ? <span className="dot" style={{ background: on ? 'rgba(255,255,255,.85)' : catColor(c) }}></span> : null}
+                  {c}
+                </button>
+              )
+            })}
+          </div>
+          {groups.length === 0 ? (
+            <div className="empty-note card-pad">Tidak ada pengeluaran{filter !== 'Semua' ? ' untuk kategori ' + filter : ''}</div>
+          ) : (
+            groups.map((g) => {
+              const total = g.list.reduce((s, e) => s + e.amount, 0)
+              return (
+                <div className="day-group" key={g.k}>
+                  <div className="day-head">
+                    <span>{fmtDateLong(g.k)}</span>
+                    <span className="total">{fmtRp(total)}</span>
+                  </div>
+                  {g.list.slice().reverse().map((e) => (
+                    <ExpRow key={e.id} e={e} catColor={catColor} tag={tagOf ? tagOf(e) : null} tagStyle={tagStyle} onClick={() => onRowTap(e)} />
+                  ))}
+                </div>
+              )
+            })
+          )}
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/PaySheet.jsx
+++ b/src/components/PaySheet.jsx
@@ -1,0 +1,44 @@
+// Subscription pay sheet — set or clear this month's payment.
+// Per the prototype (and confirmed over the plan doc), "paid" is stored as
+// { date, amount }, not derived. Ported from expense-components.jsx (PaySheet).
+
+import { useState } from 'react'
+import { Sheet } from './Sheet.jsx'
+import { fmtRp, fmtDateShort } from '../lib/format.js'
+import { todayKey } from '../lib/today.js'
+
+export function PaySheet({ sub, monthPrefix, onSave, onCancelPaid, onClose }) {
+  const paid = sub.paid && sub.paid.date.startsWith(monthPrefix) ? sub.paid : null
+  const [amount, setAmount] = useState(String(paid ? paid.amount : sub.alloc))
+  const [date, setDate] = useState(paid ? paid.date : todayKey())
+  const [err, setErr] = useState('')
+
+  function submit() {
+    const a = parseInt(amount, 10)
+    if (!a || a <= 0) { setErr('Masukkan jumlah yang valid'); return }
+    onSave({ date, amount: a })
+  }
+
+  return (
+    <Sheet onClose={onClose}>
+      <div className="sheet-title">{paid ? 'Ubah Pembayaran' : 'Bayar'} · {sub.name}</div>
+      <div className="sheet-sub">Alokasi {fmtRp(sub.alloc)} · jatuh tempo {fmtDateShort(sub.due)}</div>
+      {err ? <div className="form-err">⚠️ {err}</div> : null}
+      <label className="f-label">Jumlah dibayar</label>
+      <div className="amt-wrap">
+        <span className="amt-rp">Rp</span>
+        <input className="amt-in" type="number" inputMode="numeric" step="500" value={amount}
+          onChange={(e) => { setAmount(e.target.value); setErr('') }} />
+      </div>
+      <label className="f-label">Tanggal bayar</label>
+      <input className="f-in" type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+      <div className="btn-row">
+        {paid ? (
+          <button className="btn danger" onClick={onCancelPaid}>Batalkan</button>
+        ) : null}
+        <button className="btn ghost" onClick={onClose}>Batal</button>
+        <button className="btn primary" onClick={submit}>Simpan</button>
+      </div>
+    </Sheet>
+  )
+}

--- a/src/components/ScanEntryMenu.jsx
+++ b/src/components/ScanEntryMenu.jsx
@@ -1,0 +1,36 @@
+// FAB entry menu (Import dari images / Input manual). Ported from scan-flow.jsx.
+//
+// The AI scan flow is deferred to Phase 5, so the Import option is present but
+// stubbed: tapping it shows a "segera hadir" (coming soon) note rather than
+// opening the (not-yet-built) scan flow. The manual path is the critical path.
+
+import { useState } from 'react'
+
+export function ScanEntryMenu({ onManual, onClose }) {
+  const [stub, setStub] = useState(false)
+  return (
+    <div className="menu-ovl" onClick={onClose}>
+      <div className="scan-menu" onClick={(e) => e.stopPropagation()}>
+        <button className="scan-menu-item" onClick={() => setStub(true)} aria-disabled="true">
+          <span className="smi-ic scan" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="5" y="2" width="14" height="20" rx="3" /><path d="M9 18h6" /><path d="m8.5 8.5 2.5 2.5 4-4.5" /></svg>
+          </span>
+          <span className="smi-tx">
+            <span className="smi-t">Impor dari images</span>
+            <span className="smi-s">{stub ? 'Segera hadir di fase berikutnya' : 'Screenshot GoPay & Livin’'}</span>
+          </span>
+        </button>
+        <button className="scan-menu-item" onClick={onManual}>
+          <span className="smi-ic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" /></svg>
+          </span>
+          <span className="smi-tx">
+            <span className="smi-t">Input manual</span>
+            <span className="smi-s">Isi jumlah &amp; kategori sendiri</span>
+          </span>
+        </button>
+      </div>
+      <div className="scan-menu-caret"></div>
+    </div>
+  )
+}

--- a/src/components/Sheet.jsx
+++ b/src/components/Sheet.jsx
@@ -1,0 +1,13 @@
+// Bottom-sheet wrapper. Tapping the overlay closes; taps inside don't bubble.
+// Ported from the prototype's expense-components.jsx.
+
+export function Sheet({ onClose, children }) {
+  return (
+    <div className="ovl" onClick={onClose}>
+      <div className="sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="grab"></div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/data/seed.js
+++ b/src/data/seed.js
@@ -1,0 +1,39 @@
+// Seed data for the v2 static shell (Phase 1, offline). June 2026.
+// Ported from the prototype's expense-data.jsx. In Phase 2 the store fetches
+// this from the backend; here it is the initial offline dataset.
+
+export const SEED_EXPENSES = [
+  { id: 'e01', date: '2026-06-01', time: '12:10', amount: 18000, cat: 'Makan', note: 'Nasi padang' },
+  { id: 'e02', date: '2026-06-01', time: '15:30', amount: 12000, cat: 'Jajan', note: 'Kopi susu' },
+  { id: 'e03', date: '2026-06-01', time: '19:05', amount: 15000, cat: 'Makan', note: 'Ayam geprek' },
+  { id: 'e04', date: '2026-06-02', time: '12:40', amount: 22000, cat: 'Makan', note: 'Soto ayam' },
+  { id: 'e05', date: '2026-06-02', time: '16:20', amount: 35000, cat: 'Jajan', note: 'Boba + roti' },
+  { id: 'e06', date: '2026-06-03', time: '12:25', amount: 30000, cat: 'Makan', note: 'Warteg + es teh' },
+  { id: 'e07', date: '2026-06-03', time: '17:45', amount: 8000, cat: 'Lainnya', note: 'Parkir' },
+  { id: 'e08', date: '2026-06-04', time: '13:00', amount: 25000, cat: 'Makan', note: '' },
+  { id: 'e09', date: '2026-06-04', time: '19:30', amount: 40000, cat: 'Belanja', note: 'Sabun & odol' },
+  { id: 'e10', date: '2026-06-05', time: '12:15', amount: 20000, cat: 'Makan', note: '' },
+  { id: 'e11', date: '2026-06-05', time: '15:00', amount: 10000, cat: 'Jajan', note: 'Cilok' },
+  { id: 'e12', date: '2026-06-05', time: '18:40', amount: 20000, cat: 'Cash', note: 'Tarik tunai' },
+  { id: 'e13', date: '2026-06-06', time: '10:30', amount: 145000, cat: 'Belanja', note: 'Belanja mingguan' },
+  { id: 'e14', date: '2026-06-06', time: '19:00', amount: 65000, cat: 'Makan', note: 'Makan keluarga' },
+  { id: 'e15', date: '2026-06-07', time: '11:00', amount: 85000, cat: 'Makan', note: 'Brunch' },
+  { id: 'e16', date: '2026-06-07', time: '14:20', amount: 28000, cat: 'Jajan', note: 'Es krim' },
+  { id: 'e17', date: '2026-06-07', time: '16:45', amount: 160000, cat: 'Belanja', note: 'Skincare' },
+  { id: 'e18', date: '2026-06-08', time: '12:30', amount: 19000, cat: 'Makan', note: '' },
+  { id: 'e19', date: '2026-06-08', time: '15:10', amount: 9000, cat: 'Jajan', note: 'Gorengan' },
+  { id: 'e20', date: '2026-06-09', time: '12:45', amount: 26000, cat: 'Makan', note: 'Mie ayam' },
+  { id: 'e21', date: '2026-06-09', time: '17:00', amount: 30000, cat: 'Lainnya', note: 'Kado kantor' },
+  { id: 'e22', date: '2026-06-10', time: '12:20', amount: 24000, cat: 'Makan', note: '' },
+  { id: 'e23', date: '2026-06-10', time: '16:30', amount: 14000, cat: 'Jajan', note: 'Kopi' },
+  { id: 'e24', date: '2026-06-11', time: '12:50', amount: 32000, cat: 'Makan', note: 'Padang lagi' },
+  { id: 'e25', date: '2026-06-11', time: '18:15', amount: 50000, cat: 'Cash', note: 'Tarik tunai' },
+  { id: 'e26', date: '2026-06-12', time: '08:15', amount: 16000, cat: 'Makan', note: 'Sarapan bubur' },
+]
+
+export const SEED_SUBS = [
+  { id: 's1', name: 'Netflix', color: '#c8403c', alloc: 187000, due: '2026-06-05', paid: { date: '2026-06-05', amount: 186000 } },
+  { id: 's2', name: 'Spotify', color: '#1faa5d', alloc: 55000, due: '2026-06-10', paid: { date: '2026-06-10', amount: 65000 } },
+  { id: 's3', name: 'YouTube Premium', color: '#d04545', alloc: 59000, due: '2026-06-18', paid: null },
+  { id: 's4', name: 'iCloud+', color: '#4a7fd6', alloc: 29000, due: '2026-06-28', paid: null },
+]

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,0 +1,51 @@
+// Client state persistence for the v2 shell.
+//
+// Phase 1: localStorage is the source of truth (offline, seeded). Phase 2 wires
+// these to the backend and keeps localStorage only as an offline cache.
+
+import { SEED_EXPENSES, SEED_SUBS } from './seed.js'
+
+const STORE_KEY = 'shanci-amplop-v2'
+
+/** Load the store from localStorage, falling back to seed data. */
+export function loadStore() {
+  try {
+    const raw = typeof localStorage !== 'undefined' && localStorage.getItem(STORE_KEY)
+    if (raw) {
+      const s = JSON.parse(raw)
+      if (s && Array.isArray(s.expenses) && Array.isArray(s.subs)) return s
+    }
+  } catch { /* ignore corrupt/unavailable storage */ }
+  return { expenses: SEED_EXPENSES, subs: SEED_SUBS }
+}
+
+/** Persist the store to localStorage (best effort). */
+export function saveStore(store) {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(STORE_KEY, JSON.stringify(store))
+  } catch { /* ignore storage quota/availability errors */ }
+}
+
+/**
+ * Group a month's expenses by day key, injecting subscription payments as
+ * synthetic "Langganan" rows (the prototype's behaviour — subs surface in the
+ * day/history views even though they aren't manual expenses). Rows sorted by time.
+ */
+export function buildByDay(expenses, subs, monthPrefix) {
+  const byDay = {}
+  expenses.forEach((e) => {
+    if (e.date.indexOf(monthPrefix) === 0) {
+      (byDay[e.date] = byDay[e.date] || []).push(e)
+    }
+  })
+  subs.forEach((s) => {
+    if (s.paid && s.paid.date.indexOf(monthPrefix) === 0) {
+      const v = { id: 'sub-' + s.id, date: s.paid.date, time: '', amount: s.paid.amount, cat: 'Langganan', note: s.name, sub: true, subId: s.id }
+      ;(byDay[v.date] = byDay[v.date] || []).push(v)
+    }
+  })
+  Object.keys(byDay).forEach((k) => {
+    byDay[k].sort((a, b) => (a.time || '').localeCompare(b.time || ''))
+  })
+  return byDay
+}

--- a/src/lib/amplop-engine.js
+++ b/src/lib/amplop-engine.js
@@ -1,0 +1,102 @@
+// ============================================================
+// v2 Amplop — envelope budget engine (pure, unit-tested)
+//
+// Attribution rules (amplopOf):
+//  - Belanja & Cash                 -> Belanja Mingguan (any day)
+//  - Makan & Jajan on a weekday     -> Belanja Mingguan
+//  - Makan & Jajan on Sat/Sun       -> Akhir Pekan
+//  - Lainnya on Sat/Sun             -> Akhir Pekan
+//  - Lainnya on a weekday           -> Fleksibel
+//  - subscription payments          -> Langganan (handled via `subs`, not here)
+// Month boundaries:
+//  - a shopping week (Mon–Sun) belongs to the month of its FRIDAY
+//  - a weekend (Sat+Sun) belongs to the month of its SATURDAY
+// ============================================================
+
+import { keyToDate, dateKey, pad2, MONTHS_ID } from './dates.js'
+import { fmtK, fmtDateShort } from './format.js'
+
+export function addDaysK(k, n) {
+  const d = keyToDate(k)
+  d.setDate(d.getDate() + n)
+  return dateKey(d.getFullYear(), d.getMonth(), d.getDate())
+}
+
+export function dowsInMonth(y, m, dow) {
+  const dim = new Date(y, m + 1, 0).getDate()
+  const out = []
+  for (let d = 1; d <= dim; d++) {
+    if (new Date(y, m, d).getDay() === dow) out.push(dateKey(y, m, d))
+  }
+  return out
+}
+
+export function amplopOf(e) {
+  if (e.cat === 'Belanja' || e.cat === 'Cash') return 'belanja'
+  const dow = keyToDate(e.date).getDay()
+  const wknd = dow === 0 || dow === 6
+  if (e.cat === 'Makan' || e.cat === 'Jajan') return wknd ? 'weekend' : 'belanja'
+  return wknd ? 'weekend' : 'fleksibel'
+}
+
+export function fmtRange(aK, bK) {
+  const a = keyToDate(aK), b = keyToDate(bK)
+  if (a.getMonth() === b.getMonth()) {
+    return a.getDate() + '–' + b.getDate() + ' ' + MONTHS_ID[a.getMonth()].slice(0, 3)
+  }
+  return fmtDateShort(aK) + ' – ' + fmtDateShort(bK)
+}
+
+export function computeAmplop(expenses, subs, y, m, cfg) {
+  const monthPrefix = y + '-' + pad2(m + 1)
+  const sum = (list) => list.reduce((s, e) => s + e.amount, 0)
+
+  // Shopping weeks: one per Friday in the month, range Mon–Sun (each week stands alone).
+  const weeks = dowsInMonth(y, m, 5).map((fk, i) => {
+    const monK = addDaysK(fk, -4), sunK = addDaysK(fk, 2)
+    const spent = sum(expenses.filter((e) => amplopOf(e) === 'belanja' && e.date >= monK && e.date <= sunK))
+    const w = { i, friK: fk, monK, sunK, budget: cfg.shopWeekly, carryIn: 0, spent }
+    w.left = w.budget - w.spent
+    return w
+  })
+
+  // Weekends: one per Saturday in the month, range Sat+Sun (each weekend stands alone).
+  const weekends = dowsInMonth(y, m, 6).map((sk, i) => {
+    const sunK = addDaysK(sk, 1)
+    const spent = sum(expenses.filter((e) => amplopOf(e) === 'weekend' && (e.date === sk || e.date === sunK)))
+    const w = { i, satK: sk, sunK, budget: cfg.weekendBudget, carryIn: 0, spent }
+    w.left = w.budget - w.spent
+    return w
+  })
+
+  const subsAlloc = subs.reduce((s, x) => s + x.alloc, 0)
+  const subsPaid = subs.reduce((s, x) => s + (x.paid && x.paid.date.indexOf(monthPrefix) === 0 ? x.paid.amount : 0), 0)
+  const flexSpent = sum(expenses.filter((e) => e.date.indexOf(monthPrefix) === 0 && amplopOf(e) === 'fleksibel'))
+
+  const shopBudget = cfg.shopWeekly * weeks.length
+  const shopSpent = weeks.reduce((s, w) => s + w.spent, 0)
+  const wkndBudget = cfg.weekendBudget * weekends.length
+  const wkndSpent = weekends.reduce((s, w) => s + w.spent, 0)
+  const flexBudget = cfg.monthly - shopBudget - wkndBudget - subsAlloc
+  const totalSpent = shopSpent + wkndSpent + subsPaid + flexSpent
+
+  const friMap = {}, satMap = {}
+  weeks.forEach((w) => { friMap[w.friK] = w })
+  weekends.forEach((w) => { satMap[w.satK] = w })
+
+  return {
+    monthPrefix,
+    weeks, weekends, friMap, satMap,
+    shopBudget, shopSpent,
+    wkndBudget, wkndSpent,
+    subsAlloc, subsPaid,
+    flexBudget, flexSpent, flexLeft: flexBudget - flexSpent,
+    totalSpent, sisa: cfg.monthly - totalSpent,
+    rows: [
+      { id: 'belanja', label: 'Belanja Mingguan', budget: shopBudget, spent: shopSpent, sub: weeks.length + ' Jumat × ' + fmtK(cfg.shopWeekly) },
+      { id: 'weekend', label: 'Akhir Pekan', budget: wkndBudget, spent: wkndSpent, sub: weekends.length + ' akhir pekan × ' + fmtK(cfg.weekendBudget) },
+      { id: 'langganan', label: 'Langganan', budget: subsAlloc, spent: subsPaid, sub: subs.length + ' langganan' },
+      { id: 'fleksibel', label: 'Fleksibel', budget: flexBudget, spent: flexSpent, sub: 'sisanya, bisa minus' },
+    ],
+  }
+}

--- a/src/lib/amplop-engine.test.js
+++ b/src/lib/amplop-engine.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { amplopOf, computeAmplop, addDaysK, dowsInMonth } from './amplop-engine.js'
+import { budgetConfig } from './config.js'
+import { SEED_EXPENSES, SEED_SUBS } from '../data/seed.js'
+
+// Reference weekdays in 2026 (verified): 2026-06-01 is a Monday,
+// 2026-06-06 a Saturday, 2026-06-07 a Sunday.
+const WEEKDAY = '2026-06-01'
+const SAT = '2026-06-06'
+const SUN = '2026-06-07'
+
+describe('amplopOf — category attribution', () => {
+  it('Belanja and Cash go to Belanja Mingguan on any day', () => {
+    expect(amplopOf({ cat: 'Belanja', date: SAT })).toBe('belanja')
+    expect(amplopOf({ cat: 'Cash', date: SUN })).toBe('belanja')
+    expect(amplopOf({ cat: 'Belanja', date: WEEKDAY })).toBe('belanja')
+  })
+
+  it('Makan and Jajan on a weekday go to Belanja Mingguan', () => {
+    expect(amplopOf({ cat: 'Makan', date: WEEKDAY })).toBe('belanja')
+    expect(amplopOf({ cat: 'Jajan', date: WEEKDAY })).toBe('belanja')
+  })
+
+  it('Makan and Jajan on a weekend go to Akhir Pekan', () => {
+    expect(amplopOf({ cat: 'Makan', date: SAT })).toBe('weekend')
+    expect(amplopOf({ cat: 'Jajan', date: SUN })).toBe('weekend')
+  })
+
+  it('Lainnya goes to Akhir Pekan on a weekend, Fleksibel on a weekday', () => {
+    expect(amplopOf({ cat: 'Lainnya', date: SAT })).toBe('weekend')
+    expect(amplopOf({ cat: 'Lainnya', date: WEEKDAY })).toBe('fleksibel')
+  })
+})
+
+describe('date helpers', () => {
+  it('addDaysK crosses month boundaries', () => {
+    expect(addDaysK('2026-06-29', 6)).toBe('2026-07-05')
+    expect(addDaysK('2026-02-01', -1)).toBe('2026-01-31')
+  })
+
+  it('dowsInMonth lists the Fridays (dow 5) of June 2026', () => {
+    expect(dowsInMonth(2026, 5, 5)).toEqual(['2026-06-05', '2026-06-12', '2026-06-19', '2026-06-26'])
+  })
+})
+
+describe('computeAmplop — month-boundary rules', () => {
+  const cfg = budgetConfig()
+
+  // A shopping week belongs to the month of its FRIDAY. The week of Friday
+  // 2026-07-03 runs Mon 2026-06-29 .. Sun 2026-07-05, so a Belanja expense on
+  // 2026-06-29 counts toward JULY, not June.
+  it('shopping spend on Mon 2026-06-29 lands in July (its Friday is in July)', () => {
+    const exp = [{ id: 'x', date: '2026-06-29', time: '10:00', amount: 100000, cat: 'Belanja', note: '' }]
+    const june = computeAmplop(exp, [], 2026, 5, cfg)
+    const july = computeAmplop(exp, [], 2026, 6, cfg)
+    expect(june.shopSpent).toBe(0)
+    expect(july.shopSpent).toBe(100000)
+  })
+
+  // A weekend belongs to the month of its SATURDAY. 2026-01-31 is a Saturday
+  // and 2026-02-01 the Sunday, so a weekend expense on Sun 2026-02-01 counts
+  // toward JANUARY, not February.
+  it('weekend spend on Sun 2026-02-01 lands in January (its Saturday is in January)', () => {
+    const exp = [{ id: 'x', date: '2026-02-01', time: '13:00', amount: 70000, cat: 'Makan', note: '' }]
+    const jan = computeAmplop(exp, [], 2026, 0, cfg)
+    const feb = computeAmplop(exp, [], 2026, 1, cfg)
+    expect(jan.wkndSpent).toBe(70000)
+    expect(feb.wkndSpent).toBe(0)
+  })
+})
+
+describe('computeAmplop — budgets and subscriptions (June 2026 seed)', () => {
+  const A = computeAmplop(SEED_EXPENSES, SEED_SUBS, 2026, 5, budgetConfig())
+
+  it('derives the four envelope rows', () => {
+    expect(A.rows.map((r) => r.id)).toEqual(['belanja', 'weekend', 'langganan', 'fleksibel'])
+  })
+
+  it('sizes budgets from the number of Fridays/Saturdays in the month', () => {
+    expect(A.shopBudget).toBe(600000 * 4) // 4 Fridays in June 2026
+    expect(A.wkndBudget).toBe(200000 * 4) // 4 Saturdays in June 2026
+  })
+
+  it('allocates and derives paid subscriptions for the month', () => {
+    expect(A.subsAlloc).toBe(187000 + 55000 + 59000 + 29000)
+    expect(A.subsPaid).toBe(186000 + 65000) // Netflix + Spotify paid in June
+  })
+
+  it('computes the flexible budget as the remainder', () => {
+    expect(A.flexBudget).toBe(5000000 - A.shopBudget - A.wkndBudget - A.subsAlloc)
+    expect(A.sisa).toBe(5000000 - A.totalSpent)
+  })
+})

--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -1,0 +1,35 @@
+// Categories and category/envelope colour + tag mapping for the v2 UI.
+//
+// Note (deliberate divergence from plan doc §7.2): the manual categories are
+// exactly the prototype's set — there is NO manual "Langganan" category.
+// Subscription payments surface as a synthetic row tagged "Langganan"; see
+// data/store.js. Ported from amplop-app.jsx.
+
+import { CFG, FLEX_COLOR } from './config.js'
+import { amplopOf } from './amplop-engine.js'
+
+export const CATS = ['Makan', 'Belanja', 'Jajan', 'Cash', 'Lainnya']
+
+/** Colour for an expense category chip/dot. */
+export function catColor(cat) {
+  if (cat === 'Langganan') return '#8a8da6'
+  const i = CATS.indexOf(cat)
+  return CFG.catPalette[i >= 0 ? i : 4]
+}
+
+/** Colour for an envelope id (belanja/weekend/langganan/fleksibel). */
+export function envColor(id) {
+  if (id === 'belanja') return catColor('Belanja')
+  if (id === 'weekend') return '#d6569b'
+  if (id === 'langganan') return '#8a8da6'
+  return FLEX_COLOR
+}
+
+const AMP_LABELS = { belanja: 'BLNJ', weekend: 'WKND', fleksibel: 'FLEX', langganan: 'SUBS' }
+const AMP_FULL = { belanja: 'Belanja Mingguan', weekend: 'Akhir Pekan', fleksibel: 'Fleksibel', langganan: 'Langganan' }
+
+/** Envelope tag (label/full/color) for an expense or synthetic subscription row. */
+export function tagOf(e) {
+  const id = e.sub ? 'langganan' : amplopOf(e)
+  return { label: AMP_LABELS[id], full: AMP_FULL[id], color: envColor(id) }
+}

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,0 +1,20 @@
+// v2 "Amplop" app configuration. In the prototype this was the fixed CFG in
+// amplop-app.jsx. Per plan §5.2/§7.4 the budget figures (monthly/shopWeekly/
+// weekendBudget) become server-provided / user-editable in a later phase; for
+// Phase 1 they live here as constants.
+
+export const CFG = {
+  accent: '#5b63d3',
+  cellH: 78,
+  catPalette: ['#d35d4a', '#4968c4', '#9b59c0', '#2f9e8f', '#e0962a'],
+  monthly: 5000000,
+  shopWeekly: 600000,
+  weekendBudget: 200000,
+}
+
+export const FLEX_COLOR = '#e0962a' // amber — distinct from the Belanja Mingguan blue
+
+/** The budget subset passed to the engine's computeAmplop. */
+export function budgetConfig() {
+  return { monthly: CFG.monthly, shopWeekly: CFG.shopWeekly, weekendBudget: CFG.weekendBudget }
+}

--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -1,0 +1,36 @@
+// Date helpers for the v2 "Amplop" UI. Dates are stored as 'YYYY-MM-DD' keys.
+// Ported from the prototype's expense-data.jsx (pure, no globals).
+
+export const MONTHS_ID = [
+  'Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni',
+  'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember',
+]
+export const DOWS_FULL = ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu']
+export const DOWS_HEAD = ['Sen', 'Sel', 'Rab', 'Kam', 'Jum', 'Sab', 'Min']
+
+export function pad2(n) { return String(n).padStart(2, '0') }
+
+export function dateKey(y, m, d) { return y + '-' + pad2(m + 1) + '-' + pad2(d) }
+
+export function keyToDate(k) {
+  const p = k.split('-').map(Number)
+  return new Date(p[0], p[1] - 1, p[2])
+}
+
+export function isWeekendKey(k) {
+  const dow = keyToDate(k).getDay()
+  return dow === 0 || dow === 6
+}
+
+// Month grid, one row per week, Monday-start. null = empty cell.
+export function monthGrid(y, m) {
+  const lead = (new Date(y, m, 1).getDay() + 6) % 7
+  const dim = new Date(y, m + 1, 0).getDate()
+  const cells = []
+  for (let i = 0; i < lead; i++) cells.push(null)
+  for (let d = 1; d <= dim; d++) cells.push(dateKey(y, m, d))
+  while (cells.length % 7) cells.push(null)
+  const weeks = []
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7))
+  return weeks
+}

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,25 +1,49 @@
 // Canonical formatting helpers for the v2 "Amplop" UI.
 //
-// Per CLAUDE.md, currency must be formatted through shared helpers rather than
-// hand-rolled at each call site. This module is the single source for that.
-//
-// Phase 0 establishes `fmtRp` (full Rupiah). The compact `fmtK` form and the
-// remaining `expense-data` helpers (dates, categories) are ported in Phase 1
-// from the prototype bundle, where their exact display format is defined.
+// Per CLAUDE.md, currency/date display must go through these shared helpers
+// rather than being hand-rolled at each call site. Ported from the prototype's
+// expense-data.jsx so the production output matches the design pixel-for-pixel.
+
+import { keyToDate, MONTHS_ID, DOWS_FULL } from './dates.js'
+
+const MINUS = '−' // U+2212 MINUS SIGN (matches the prototype, not '-')
 
 /**
- * Format an integer amount as Indonesian Rupiah, e.g. 5000000 -> "Rp5.000.000".
- *
- * Amounts in v2 are integers (no decimals). Non-finite input is treated as 0
- * so a bad value can never render "RpNaN" in the UI. Negative values (the
- * Fleksibel envelope can go negative) render as "-Rp5.000".
- *
- * @param {number} amount integer rupiah
- * @returns {string}
+ * Compact amount: 50000 -> "50K", 1250000 -> "1,25Jt", -5000 -> "−5K".
+ * Negative envelope figures (e.g. Fleksibel) render with a leading minus sign.
  */
-export function fmtRp(amount) {
-  const n = Number.isFinite(amount) ? Math.trunc(amount) : 0
-  const sign = n < 0 ? '-' : ''
-  const grouped = Math.abs(n).toLocaleString('id-ID')
-  return `${sign}Rp${grouped}`
+export function fmtK(n) {
+  const v = Number.isFinite(n) ? n : 0
+  const neg = v < 0
+  const a = Math.abs(v)
+  let s
+  if (a >= 1000000) s = (a / 1000000).toLocaleString('id-ID', { maximumFractionDigits: 2 }) + 'Jt'
+  else if (a >= 1000) s = (a / 1000).toLocaleString('id-ID', { maximumFractionDigits: 1 }) + 'K'
+  else s = String(a)
+  return (neg ? MINUS : '') + s
+}
+
+/**
+ * Full Rupiah: 5000000 -> "Rp5.000.000".
+ *
+ * Matches the prototype, which formats the absolute value (callers only ever
+ * pass positive amounts; negative figures use {@link fmtK}, which carries its
+ * own minus sign). Non-finite input is treated as 0 so a bad value can never
+ * render "RpNaN".
+ */
+export function fmtRp(n) {
+  const a = Number.isFinite(n) ? Math.trunc(Math.abs(n)) : 0
+  return 'Rp' + a.toLocaleString('id-ID')
+}
+
+/** "Senin, 16 Juni 2026" */
+export function fmtDateLong(k) {
+  const d = keyToDate(k)
+  return DOWS_FULL[d.getDay()] + ', ' + d.getDate() + ' ' + MONTHS_ID[d.getMonth()] + ' ' + d.getFullYear()
+}
+
+/** "16 Jun" */
+export function fmtDateShort(k) {
+  const d = keyToDate(k)
+  return d.getDate() + ' ' + MONTHS_ID[d.getMonth()].slice(0, 3)
 }

--- a/src/lib/format.test.js
+++ b/src/lib/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { fmtRp } from './format.js'
+import { fmtRp, fmtK } from './format.js'
 
 describe('fmtRp', () => {
   it('formats millions with dot thousands separators (id-ID)', () => {
@@ -18,8 +18,10 @@ describe('fmtRp', () => {
     expect(fmtRp(750)).toBe('Rp750')
   })
 
-  it('renders the sign before the Rp prefix for negatives (Fleksibel can go negative)', () => {
-    expect(fmtRp(-5000)).toBe('-Rp5.000')
+  // Matches the prototype: fmtRp shows the absolute value (callers never pass
+  // negatives; negative figures use fmtK, which carries its own minus sign).
+  it('formats the absolute value for negatives', () => {
+    expect(fmtRp(-5000)).toBe('Rp5.000')
   })
 
   it('truncates fractional input to an integer', () => {
@@ -31,5 +33,27 @@ describe('fmtRp', () => {
     expect(fmtRp(NaN)).toBe('Rp0')
     expect(fmtRp(Infinity)).toBe('Rp0')
     expect(fmtRp(undefined)).toBe('Rp0')
+  })
+})
+
+describe('fmtK', () => {
+  it('formats sub-thousands verbatim', () => {
+    expect(fmtK(750)).toBe('750')
+  })
+
+  it('formats thousands with a K suffix', () => {
+    expect(fmtK(50000)).toBe('50K')
+  })
+
+  it('formats millions with a Jt suffix and id-ID decimals', () => {
+    expect(fmtK(1250000)).toBe('1,25Jt')
+  })
+
+  it('renders a U+2212 minus for negatives', () => {
+    expect(fmtK(-5000)).toBe('−5K')
+  })
+
+  it('treats non-finite input as zero', () => {
+    expect(fmtK(NaN)).toBe('0')
   })
 })

--- a/src/lib/today.js
+++ b/src/lib/today.js
@@ -1,0 +1,19 @@
+// Single source of "now" for the v2 UI. The prototype hard-pinned TODAY to
+// 2026-06-16 for a deterministic demo; production uses the real clock. Kept in
+// one module so tests (and future features) can inject a fixed clock instead.
+
+import { dateKey } from './dates.js'
+
+let _now = () => new Date()
+
+/** Override the clock (tests/demos). Pass no args to reset to the real clock. */
+export function setNow(fn) { _now = fn || (() => new Date()) }
+
+/** Current Date per the active clock. */
+export function now() { return _now() }
+
+/** Today's 'YYYY-MM-DD' key per the active clock. */
+export function todayKey() {
+  const d = _now()
+  return dateKey(d.getFullYear(), d.getMonth(), d.getDate())
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,12 @@
+// React entry for the v2 "Amplop" shell. Mounted from v2.html.
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './app.jsx'
+import './styles/tokens.css'
+import './styles/app.css'
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,752 @@
+/* v2 "Amplop" styles, ported from the prototype <style> block.
+   Tokens live in tokens.css. Scan-flow gallery/processing/review styles
+   are deferred to Phase 5; only the FAB entry-menu and form scan-banner
+   (both rendered by the Phase 1 shell) are included here. */
+
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    background: #e7e7ee;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+}
+button { font-family: inherit; }
+
+.app {
+    max-width: 430px;
+    margin: 0 auto;
+    min-height: 100vh;
+    background: var(--bg);
+    box-shadow: 0 0 44px rgba(40, 40, 90, 0.10);
+    padding-bottom: 110px;
+    position: relative;
+}
+
+/* ---------- Header ---------- */
+.topbar {
+    background: linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 60%, #241c4a));
+    padding: 20px 16px 58px;
+    color: #fff;
+}
+.month-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+.month-center { text-align: center; min-width: 0; }
+.month-title { font-size: 21px; font-weight: 700; letter-spacing: 0.01em; }
+.month-sub { font-size: 11.5px; opacity: 0.78; margin-top: 3px; font-weight: 500; }
+.nav-btn {
+    width: 40px;
+    height: 40px;
+    flex: none;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+    border: none;
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    padding-bottom: 3px;
+}
+.nav-btn:active { background: rgba(255, 255, 255, 0.3); }
+.today-pill {
+    display: block;
+    margin: 12px auto 0;
+    border: none;
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 6px 14px;
+    border-radius: 999px;
+    cursor: pointer;
+}
+
+/* ---------- Stat strip ---------- */
+.stat-strip {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    background: var(--surface);
+    border-radius: 16px;
+    margin: -40px 14px 0;
+    box-shadow: 0 8px 28px rgba(40, 40, 90, 0.12);
+    padding: 14px 4px;
+    position: relative;
+}
+.stat { text-align: center; }
+.stat.mid { border-left: 1px solid var(--line); border-right: 1px solid var(--line); }
+.stat-label {
+    font-size: 10.5px;
+    color: var(--muted);
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+.stat-value {
+    font-size: 17px;
+    font-weight: 700;
+    margin-top: 3px;
+    font-variant-numeric: tabular-nums;
+}
+.stat-value.g { color: var(--green); }
+.stat-value.r { color: var(--red); }
+.mini-v.g { color: var(--green); }
+.mini-v.r { color: var(--red); }
+
+/* ---------- Cards ---------- */
+.card {
+    background: var(--surface);
+    border-radius: 16px;
+    margin: 14px;
+    box-shadow: 0 2px 12px rgba(40, 40, 90, 0.05);
+    overflow: hidden;
+}
+
+/* ---------- Kalender ---------- */
+.cal-head {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    padding: 10px 0 7px;
+    border-bottom: 1px solid var(--line);
+}
+.cal-dow {
+    text-align: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--muted);
+    letter-spacing: 0.03em;
+}
+.cal-dow.wk { color: color-mix(in srgb, var(--accent) 75%, var(--muted)); }
+.cal-row { display: grid; grid-template-columns: repeat(7, 1fr); }
+.cell {
+    appearance: none;
+    background: none;
+    border: none;
+    border-top: 1px solid var(--line);
+    padding: 5px 2px 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
+    cursor: pointer;
+    overflow: hidden;
+    color: var(--ink);
+}
+.cal-row:first-of-type .cell { border-top: none; }
+.cell.empty { cursor: default; }
+.cell.wknd { background: color-mix(in srgb, var(--accent) 4%, transparent); }
+.cell:not(.empty):active { background: color-mix(in srgb, var(--accent) 11%, transparent); }
+.dnum {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--muted);
+    width: 20px;
+    height: 20px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    font-variant-numeric: tabular-nums;
+}
+.cell.today .dnum { background: var(--accent); color: #fff; font-weight: 700; }
+.cellstack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    flex: 1;
+    justify-content: center;
+    min-height: 0;
+}
+.spent {
+    font-size: 12.5px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+.diff {
+    font-size: 10.5px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    padding: 1px 5px;
+    border-radius: 6px;
+    white-space: nowrap;
+}
+.diff.pos { color: var(--green); background: var(--green-bg); }
+.diff.neg { color: var(--red); background: var(--red-bg); }
+.allow-lbl {
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+    opacity: 0.85;
+}
+.allow { font-size: 13px; font-weight: 800; color: var(--accent); font-variant-numeric: tabular-nums; }
+.allow.over { color: var(--red); }
+.plan {
+    font-size: 12px;
+    font-weight: 600;
+    color: color-mix(in srgb, var(--accent) 52%, var(--muted));
+    font-variant-numeric: tabular-nums;
+}
+.nodata { color: #d4d4e2; font-weight: 700; flex: 1; display: grid; place-items: center; }
+
+/* ---------- Section headers ---------- */
+.sec-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin: 24px 18px 0;
+}
+.sec-title { font-size: 15.5px; font-weight: 700; }
+.sec-meta { font-size: 11.5px; color: var(--muted); font-weight: 600; text-align: right; display: flex; align-items: center; gap: 6px; }
+.sec-toggle {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    width: calc(100% - 36px);
+    cursor: pointer;
+    color: var(--ink);
+    align-items: center;
+}
+.sec-caret {
+    display: inline-block;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--muted);
+    transition: transform 0.18s ease;
+    transform: rotate(90deg);
+    line-height: 1;
+}
+.sec-caret.open { transform: rotate(-90deg); }
+.subs-card { animation: subs-in 0.2s ease; }
+@keyframes subs-in { from { opacity: 0; transform: translateY(-6px); } }
+
+/* ---------- Langganan ---------- */
+.sub-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 12px 14px;
+    border: none;
+    border-top: 1px solid var(--line);
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--ink);
+}
+.sub-row.first { border-top: none; }
+.sub-row { padding: 13px 16px; }
+.sub-row:active { background: var(--bg); }
+.sub-ic {
+    width: 38px;
+    height: 38px;
+    flex: none;
+    border-radius: 11px;
+    display: grid;
+    place-items: center;
+    font-weight: 800;
+    color: #fff;
+    font-size: 16px;
+}
+.sub-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.sub-name { font-weight: 600; font-size: 14px; }
+.sub-sub { font-size: 11.5px; color: var(--muted); font-weight: 500; }
+.sub-right {
+    margin-left: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 3px;
+    flex: none;
+}
+.sub-amt { font-weight: 700; font-size: 14px; font-variant-numeric: tabular-nums; }
+.pay-tag {
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 11%, white);
+    padding: 2px 10px;
+    border-radius: 7px;
+}
+
+/* ---------- Chips ---------- */
+.chips {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 12px 18px 2px;
+    scrollbar-width: none;
+}
+.chips::-webkit-scrollbar { display: none; }
+.cat-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    border-radius: 999px;
+    padding: 7px 13px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--ink);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    flex: none;
+}
+.chip.on { border-color: transparent; color: #fff; }
+.chip .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+
+/* ---------- Daftar ---------- */
+.day-group {
+    margin: 12px 14px;
+    background: var(--surface);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(40, 40, 90, 0.05);
+}
+.day-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--accent) 5%, white);
+    font-size: 12.5px;
+    font-weight: 700;
+}
+.day-head .total { font-variant-numeric: tabular-nums; color: var(--muted); }
+.exp-row {
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    width: 100%;
+    padding: 11px 14px;
+    border: none;
+    border-top: 1px solid var(--line);
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--ink);
+}
+.exp-row:active { background: var(--bg); }
+.cat-dot { width: 10px; height: 10px; border-radius: 4px; flex: none; }
+.exp-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.exp-cat { font-size: 13.5px; font-weight: 600; display: flex; align-items: center; gap: 7px; }
+.amp-tag {
+    font-size: 9.5px;
+    font-weight: 800;
+    letter-spacing: 0.05em;
+    padding: 2px 6px;
+    border-radius: 6px;
+    line-height: 1.2;
+    flex: none;
+}
+.exp-row.has-bar { position: relative; }
+.amp-bar {
+    position: absolute;
+    left: 0;
+    top: 8px;
+    bottom: 8px;
+    width: 3.5px;
+    border-radius: 0 2px 2px 0;
+}
+.exp-note {
+    font-size: 11.5px;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+}
+.exp-right { margin-left: auto; text-align: right; flex: none; }
+.exp-amt { font-size: 13.5px; font-weight: 700; font-variant-numeric: tabular-nums; display: block; }
+.exp-time { font-size: 11px; color: var(--muted); display: block; margin-top: 1px; }
+.empty-note { padding: 18px; text-align: center; color: var(--muted); font-size: 13px; }
+.empty-note.card-pad { margin: 12px 14px; background: var(--surface); border-radius: 16px; }
+
+/* ---------- FAB ---------- */
+.fab {
+    position: fixed;
+    bottom: 24px;
+    right: max(18px, calc(50% - 197px));
+    width: 56px;
+    height: 56px;
+    border-radius: 17px;
+    background: var(--accent, #5b63d3);
+    color: #fff;
+    border: none;
+    font-size: 28px;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 10px 24px color-mix(in srgb, var(--accent, #5b63d3) 42%, transparent);
+    z-index: 40;
+    display: grid;
+    place-items: center;
+    padding-bottom: 4px;
+}
+.fab:active { transform: scale(0.94); }
+
+/* ---------- Bottom sheet ---------- */
+.ovl {
+    position: fixed;
+    inset: 0;
+    background: rgba(26, 23, 52, 0.46);
+    z-index: 50;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    animation: ovl-fade 0.18s ease;
+}
+.sheet {
+    background: var(--surface);
+    width: 100%;
+    max-width: 430px;
+    border-radius: 22px 22px 0 0;
+    padding: 8px 18px calc(20px + env(safe-area-inset-bottom));
+    max-height: 84vh;
+    overflow-y: auto;
+    animation: sheet-up 0.26s cubic-bezier(0.32, 0.72, 0.33, 1);
+}
+.grab {
+    width: 38px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--line);
+    margin: 4px auto 14px;
+}
+@keyframes sheet-up { from { transform: translateY(48px); opacity: 0; } }
+@keyframes ovl-fade { from { opacity: 0; } }
+.sheet-title { font-size: 17px; font-weight: 700; }
+.sheet-sub { font-size: 12px; color: var(--muted); margin-top: 3px; font-weight: 500; }
+.mini-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 8px;
+    margin: 14px 0 4px;
+}
+.mini { background: var(--bg); border-radius: 12px; padding: 10px 6px; text-align: center; }
+.mini-l {
+    font-size: 9.5px;
+    font-weight: 800;
+    text-transform: uppercase;
+    color: var(--muted);
+    letter-spacing: 0.05em;
+}
+.mini-v { font-size: 14.5px; font-weight: 700; margin-top: 2px; font-variant-numeric: tabular-nums; }
+.sheet-list { margin: 8px -18px 14px; }
+.sheet-list .exp-row { padding-left: 18px; padding-right: 18px; }
+.sheet-list .exp-row:first-child { border-top: 1px solid var(--line); }
+
+/* ---------- Form ---------- */
+.f-label {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--muted);
+    margin: 16px 0 7px;
+    display: block;
+}
+.form-err {
+    margin-top: 12px;
+    background: var(--red-bg);
+    color: var(--red);
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 9px 12px;
+    border-radius: 10px;
+}
+.amt-wrap {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--bg);
+    border-radius: 13px;
+    padding: 12px 14px;
+}
+.amt-rp { font-weight: 700; color: var(--muted); font-size: 15px; }
+.amt-in {
+    border: none;
+    background: none;
+    font-size: 23px;
+    font-weight: 700;
+    width: 100%;
+    outline: none;
+    font-family: inherit;
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+}
+.f-in {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 11px;
+    padding: 10px 12px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--ink);
+    background: var(--surface);
+    outline-color: var(--accent);
+    resize: vertical;
+}
+.form-row { display: flex; gap: 10px; }
+.time24 { display: flex; align-items: center; gap: 8px; }
+.time-sel {
+    width: auto;
+    min-width: 72px;
+    font-size: 16px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    padding: 11px 10px;
+    appearance: none;
+    background-image: none;
+}
+.time-colon { font-size: 18px; font-weight: 700; color: var(--muted); }
+.time-hint { font-size: 11.5px; color: var(--muted); font-weight: 600; margin-left: 2px; }
+.form-col { flex: 1; }
+.btn-row { display: flex; gap: 10px; margin-top: 22px; }
+.btn {
+    flex: 1;
+    border: none;
+    border-radius: 13px;
+    padding: 13px;
+    font-size: 15px;
+    font-weight: 700;
+    cursor: pointer;
+}
+.btn.primary { background: var(--accent); color: #fff; }
+.btn.primary:active { filter: brightness(0.92); }
+.btn.ghost { background: var(--bg); color: var(--ink); }
+.btn.danger { background: var(--red-bg); color: var(--red); flex: 0 0 auto; padding: 13px 18px; }
+/* ---------- v2: Kartu amplop ---------- */
+.env-card {
+    margin: -40px 14px 0;
+    box-shadow: 0 8px 28px rgba(40, 40, 90, 0.12);
+    position: relative;
+}
+.env-top {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    padding: 14px 4px;
+    border-bottom: 1px solid transparent;
+}
+.env-toggle.open { border-bottom-color: var(--line); }
+.env-toggle {
+    width: 100%;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--ink);
+    align-items: center;
+    position: relative;
+    font-family: inherit;
+}
+.env-top-caret {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%) rotate(90deg);
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--muted);
+    transition: transform 0.18s ease;
+}
+.env-top-caret.open { transform: translateY(-50%) rotate(-90deg); }
+.env-rows { padding: 5px 0; }
+.env-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 9px 14px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--ink);
+}
+.env-row:active { background: var(--bg); }
+.env-dot { width: 10px; height: 10px; border-radius: 4px; flex: none; }
+.env-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
+.env-line { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.env-label { font-size: 13px; font-weight: 600; }
+.env-nums { font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.env-nums em { font-style: normal; color: var(--muted); font-weight: 600; }
+.env-nums.r { color: var(--red); }
+.bar { display: block; height: 5px; border-radius: 3px; background: var(--bg); overflow: hidden; }
+.bar-fill { display: block; height: 100%; border-radius: 3px; }
+.env-caret { color: var(--muted); font-size: 15px; font-weight: 700; flex: none; }
+
+/* ---------- v2: Pill jadwal di sel kalender ---------- */
+.wpill {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    border-radius: 6px;
+    padding: 2px 6px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+.wpill .pdot { width: 5px; height: 5px; border-radius: 50%; flex: none; }
+.wpill.plan { background: var(--bg); color: var(--muted); }
+.wpill.now { background: color-mix(in srgb, var(--accent) 12%, white); color: var(--accent); }
+.wpill.pos { background: var(--green-bg); color: var(--green); }
+.wpill.neg { background: var(--red-bg); color: var(--red); }
+.due-dots { display: flex; gap: 3px; padding-bottom: 3px; }
+.due-dots i { width: 4px; height: 4px; border-radius: 50%; display: block; }
+
+/* ---------- v2: Sheet detail amplop ---------- */
+.env-list { margin-top: 10px; }
+.env-week {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 11px 0;
+    border-top: 1px solid var(--line);
+}
+.env-week:first-child { border-top: none; }
+.ew-left { display: flex; flex-direction: column; gap: 2px; }
+.ew-range { font-size: 13.5px; font-weight: 600; }
+.ew-note { font-size: 11px; color: var(--muted); font-weight: 500; }
+.ew-right { text-align: right; display: flex; flex-direction: column; align-items: flex-end; gap: 3px; }
+.ew-amt { font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.ew-amt em { font-style: normal; color: var(--muted); font-weight: 600; }
+.sheet-note {
+    font-size: 11.5px;
+    color: var(--muted);
+    background: var(--bg);
+    border-radius: 10px;
+    padding: 9px 12px;
+    margin-top: 12px;
+    line-height: 1.45;
+}
+.fx-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 0;
+    font-size: 13.5px;
+    border-top: 1px solid var(--line);
+    font-variant-numeric: tabular-nums;
+}
+.fx-row:first-child { border-top: none; }
+.fx-row .fx-l { color: var(--muted); font-weight: 600; }
+.fx-row .fx-v { font-weight: 700; }
+.fx-row.strong .fx-l, .fx-row.strong .fx-v { color: var(--ink); font-weight: 800; }
+.fx-row.g .fx-v { color: var(--green); }
+.fx-row.r .fx-v { color: var(--red); }
+.btn.full.ghost { margin-top: 14px; }
+
+/* ============================================================
+   Scan struk — entry menu, galeri, proses, tinjau
+   ============================================================ */
+.btn:disabled { opacity: 0.45; cursor: default; }
+
+/* ---------- Entry menu (muncul dari FAB) ---------- */
+.menu-ovl {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    background: rgba(26, 23, 52, 0.30);
+    animation: ovl-fade 0.16s ease;
+}
+.scan-menu {
+    position: absolute;
+    bottom: 92px;
+    right: max(18px, calc(50% - 197px));
+    width: 248px;
+    background: var(--surface);
+    border-radius: 18px;
+    box-shadow: 0 18px 44px rgba(30, 28, 70, 0.30);
+    padding: 7px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    transform-origin: bottom right;
+    animation: menu-pop 0.2s cubic-bezier(0.32, 0.72, 0.33, 1);
+}
+@keyframes menu-pop { from { opacity: 0; transform: translateY(10px) scale(0.94); } }
+.scan-menu-caret {
+    position: absolute;
+    bottom: 80px;
+    right: max(40px, calc(50% - 175px));
+    width: 16px;
+    height: 16px;
+    background: var(--surface);
+    transform: rotate(45deg);
+    border-radius: 0 0 4px 0;
+    box-shadow: 4px 4px 10px rgba(30, 28, 70, 0.12);
+}
+.scan-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    border: none;
+    background: none;
+    padding: 11px 12px;
+    border-radius: 13px;
+    cursor: pointer;
+    text-align: left;
+    color: var(--ink);
+}
+.scan-menu-item:active { background: var(--bg); }
+.smi-ic {
+    width: 42px;
+    height: 42px;
+    flex: none;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: var(--bg);
+    color: var(--muted);
+}
+.smi-ic.scan {
+    background: linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 62%, #241c4a));
+    color: #fff;
+}
+.smi-tx { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.smi-t { font-size: 14.5px; font-weight: 700; }
+.smi-s { font-size: 11.5px; color: var(--muted); font-weight: 500; }
+
+/* ---------- v2: scan banner in the expense form ---------- */
+/* ---------- Banner di form (variasi sheet) ---------- */
+.scan-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    margin-top: 14px;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    padding: 13px 14px;
+    border-radius: 14px;
+    color: #fff;
+    background: linear-gradient(120deg, var(--accent), color-mix(in oklab, var(--accent) 58%, #241c4a));
+    box-shadow: 0 8px 20px color-mix(in srgb, var(--accent) 32%, transparent);
+}
+.scan-banner:active { filter: brightness(0.95); }
+.sb-ic {
+    width: 40px;
+    height: 40px;
+    flex: none;
+    border-radius: 11px;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.2);
+}
+.sb-tx { flex: 1; display: flex; flex-direction: column; gap: 2px; }
+.sb-t { font-size: 14.5px; font-weight: 700; }
+.sb-s { font-size: 11.5px; opacity: 0.85; font-weight: 500; }
+.sb-go { font-size: 22px; font-weight: 700; opacity: 0.8; }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,13 @@
+/* v2 "Amplop" design tokens. The theme keys off --accent, which is set per
+   render on .app (see app.jsx cssVars); keep that the single theming knob. */
+:root {
+    --bg: #f2f2f7;
+    --surface: #ffffff;
+    --line: #e9e9f2;
+    --ink: #232438;
+    --muted: #8d8fa8;
+    --green: #1f9d5b;
+    --green-bg: #e4f4ec;
+    --red: #e04545;
+    --red-bg: #fcebeb;
+}

--- a/v2.html
+++ b/v2.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>ShanCi Expense — Amplop (v2)</title>
+</head>
+<body>
+  <!-- v2 "Amplop" shell (Phase 1, offline/seed). The live app is still index.html;
+       the Phase 3 cutover replaces it with this entry. -->
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,10 @@ export default defineConfig({
     assetsDir: 'assets',
     rollupOptions: {
       input: {
-        main: './index.html'
+        main: './index.html',
+        // v2 "Amplop" shell — built alongside the live app until the Phase 3
+        // cutover swaps index.html over to it.
+        v2: './v2.html'
       }
     }
   },


### PR DESCRIPTION
## Intent

Phase 1 of the v2 **Amplop** redesign (`docs/v2-amplop-redesign-plan.md` §8): port the handoff prototype to React/ES modules and render the full, interactive envelope-calendar UI against **seed/localStorage data** — no network (that's Phase 2), no live-app cutover (that's Phase 3).

## Architecture

- **Pure, unit-tested core** under `src/lib/`: `dates`, `format`, `categories`, `config` (budget CFG), `amplop-engine` (`computeAmplop`/`amplopOf`), and `today` (an injectable clock replacing the prototype's pinned `TODAY`).
- **Components** (`src/components/`) + orchestrator (`src/app.jsx`): envelope card, Monday-start calendar, history list, and the day / envelope / expense-form / pay bottom sheets, plus the FAB entry menu.
- **Mounted via `v2.html`** (a second Vite input). The live `index.html` app builds untouched; the Phase 3 cutover swaps it over.
- Styles split into `styles/tokens.css` + `app.css`, keyed off `--accent` (§10).

## Decisions applied this session (all ratified with the user)

- **Follow the prototype, not the plan doc**, on subscriptions: `paid: {date, amount}` is **stored** with a "Bayar" pay-sheet flow, and there is **no manual `Langganan` category**. The plan doc (§2.2/§2.3/§7.2/§7.3) is corrected to match — it had described a derived-paid model the prototype never implemented.
- **AI scan flow deferred to Phase 5**; the FAB "Impor dari images" option is present but stubbed ("segera hadir"). Manual entry is the critical path and fully works.
- **Recap** dropped on cutover (not in v2).
- `fmtRp` reconciled to the prototype's absolute-value behaviour (the Phase 0 sign handling was removed; negative figures use `fmtK`, which carries the minus).

## Out of scope (later phases)

Backend wiring (Phase 2), data migration/cutover (Phase 3), subscription CRUD (Phase 4), real scan/OCR (Phase 5). Category mapping / budget-config source / backend ownership remain open per §12 for those phases.

## Test plan

- `npm test` → **27 passing**: `format` (12), `amplop-engine` (12, incl. both month-boundary rules), `app` (3, jsdom render smoke — mounts, FAB menu opens, month nav).
- `npm run build` → green; emits `dist/v2.html` + v2 bundle alongside the intact `index.html` app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)