### PR TITLE
feat: Phase 2 v2 Amplop backend contract + wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Example environment for ShanCi Expense.
+# Copy to .env.production (or .env.local) and fill in real values.
+
+# Shared
+VITE_API_TIMEOUT=10000
+
+# --- v1 (current production app) endpoints ---
+VITE_GET_WEEKLY_EXPENSE_URL=
+VITE_ADD_WEEKLY_EXPENSE_URL=
+VITE_GET_MONTHLY_EXPENSE_URL=
+VITE_ADD_MONTHLY_EXPENSE_URL=
+VITE_GET_RECAP_URL=
+
+# --- v2 "Amplop" endpoints (Phase 2 contract; backend not built yet) ---
+# Leave these UNSET to run the v2 app on the in-repo mock (localStorage).
+# Set VITE_GET_MONTH_URL to switch the v2 app to the real backend.
+#   GET  {month}?month=YYYY-MM -> { expenses[], subs[], config:{monthly,shopWeekly,weekendBudget} }
+#                                 expenses = PADDED ±7-day window (see lib/dates.monthWindow)
+#   POST {addExpense}    body Expense(no id)   -> created Expense
+#   PUT  {updateExpense} body Expense(with id) -> updated Expense
+#   POST {deleteExpense} body { id }           -> { id }
+#   POST {setSubPayment} body { subId, paid:{date,amount}|null } -> Subscription
+VITE_GET_MONTH_URL=
+VITE_ADD_EXPENSE_URL=
+VITE_UPDATE_EXPENSE_URL=
+VITE_DELETE_EXPENSE_URL=
+VITE_SET_SUB_PAYMENT_URL=

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,12 +1,13 @@
-# Review — PR #10: Phase 1 v2 Amplop static shell (offline/seed)
+# Review — PR #11: Phase 2 v2 Amplop data-API seam
 
-First review. Scope: port the handoff React prototype to ES modules and render the
-full interactive envelope-calendar UI against seed/localStorage only — no network,
-no live-app cutover. Reviewed at HEAD cc63596.
+First review. Scope: introduce a data-API seam (`src/data/api.js`) so the v2
+shell loads/saves via endpoints with localStorage as an offline cache, plus
+loading/error/retry/notice states. Reviewed at HEAD 2913f6a.
 
-Ratified decisions honored as not-bugs: stored `paid:{date,amount}` (no manual
-Langganan category), Import FAB stubbed ("segera hadir"), v2 mounts via new
-`v2.html` with `index.html` untouched, `fmtRp` absolute-value behaviour.
+Ratified decisions honored as not-bugs: in-repo mock adapter selected by env
+flag (USE_MOCK = no VITE_GET_MONTH_URL); GET month returns server budget config;
+persist expenses + subscription payment only (full sub CRUD is Phase 4); auth
+public per §13; v2 mounts via v2.html (index.html untouched).
 
 ## Blocking
 
@@ -18,28 +19,41 @@ _None (first review, no prior blocking issues)._
 
 ## Non-blocking (nits)
 
-- `src/components/ExpenseForm.jsx:23` and `src/components/PaySheet.jsx:17`:
-  `parseInt(amount, 10)` tolerates trailing garbage ("100abc" -> 100). Acceptable
-  for an `input[type=number]`, but a stricter parse would be marginally safer.
-- `src/app.jsx:50-63` `dayMinis`: days that fall in a shopping week owned by an
-  adjacent month (e.g. Mon 2026-06-29 -> July's week) get no "Sisa belanja" mini.
-  This is consistent with the engine's month-boundary attribution and is intended,
-  not a defect — noted only for awareness.
+- nit: `src/data/api.js:163` (real `addExpense`) returns the created expense but
+  does not write it into the local `_db` cache. The subsequent `reload()` in
+  `app.jsx:67` re-fetches and re-caches, so the happy path is correct. But if
+  that reload fails after a successful server write, `getMonth` returns the
+  `_stale` cache, which lacks the just-added row — the write succeeded server-side
+  yet the UI silently omits it until the next good fetch. No data loss/corruption;
+  edge UX wrinkle for the not-yet-built real backend.
+- nit: `src/app.jsx:66-69` `reload()` discards a `_stale` flag on the post-write
+  fetch — the offline notice won't appear in that path. Cosmetic.
+- nit: `src/data/api.js:140` `cacheMonth` replaces `subs`/`config` wholesale from
+  each month fetch. Fine while subs/config are global, but if subs ever become
+  month-scoped this merge would need revisiting. Noted for awareness only.
 
 ## Verification
 
-- `npm test` -> 27 passing (format 12, engine 12, app render smoke 3). Failure paths
-  covered: format.js non-finite -> Rp0/0; engine month-boundary (Fri/Sat ownership).
-- `npm run build` -> green; emits `dist/v2.html` + v2 bundle and an intact
-  `dist/index.html` (live vanilla app builds unchanged).
-- No live-app files touched (index.html, main.js, tabs/monthly/recap/modal/details,
-  style.css all unchanged). Focused diff.
-- No secrets, no network calls in new code (Phase 1 offline scope).
-- Form validation rejects non-positive/invalid amounts in ExpenseForm and PaySheet;
-  localStorage load/save both guarded with try/catch; non-finite guards in format.js.
-- Sheet routing (closeForm/closePay/openExpense) traced: from='day' returns to day
-  sheet, from='env' returns to langganan sheet, from=null closes fully — consistent.
-- UI copy is Indonesian; currency via shared `fmtK`/`fmtRp`; conventional `feat:` commit.
+- Padded ±7-day `monthWindow` proven sufficient by brute force over 2024–2030:
+  every engine shopping week (Mon=Fri-4 .. Sun=Fri+2) and weekend (Sat .. Sun+1)
+  falls inside the window — zero failures. Boundary spend is preserved.
+- `npm test` -> 38 passing (api mock 7, api real failure paths 3, format 12,
+  engine 12, app 4). Failure paths covered: cold network -> friendly Indonesian
+  error; stale offline fallback after a prior success; non-ok HTTP -> throw;
+  app write round-trip (28 -> 29 transaksi via API).
+- `npm run build` -> green; emits dist/v2.html + v2 bundle and an intact
+  dist/index.html. No live-app files touched (index.html, main.js, tabs/monthly/
+  recap/modal/details/style.css all unchanged) — focused diff.
+- No nil/zero read of `A`/`cfg` when `data` is null: every use is behind a
+  `data ?` gate or a `data &&` sheet guard. Loading/error/retry/notice wired;
+  write errors surface via `notice`.
+- Module-level `_db`/`_hasCache`/`_seq` cleared by `_resetLocal()` (called in
+  test `beforeEach`); real-adapter tests use `vi.resetModules()`. No cross-test
+  state leak; `_stale` only after an in-session success (intentional).
+- `friendly()` maps Timeout/Abort + "Failed to fetch" to Indonesian copy, else
+  preserves the Error. All fetches carry `AbortSignal.timeout(TIMEOUT)`.
+- CLAUDE.md: UI copy Indonesian; currency via shared `fmtK`; no secrets
+  (.env.example placeholders empty); conventional `feat:` commit.
 
 ## Blocking issues
 _None._

--- a/docs/v2-amplop-redesign-plan.md
+++ b/docs/v2-amplop-redesign-plan.md
@@ -321,11 +321,18 @@ endpoint) instead of the hard-coded `CFG`. Required for §5.2.
 - Note: built to the **prototype**, not the original §2.2/§7.3 text — those
   sections were corrected (subscriptions store `paid`; no manual Langganan).
 
-**Phase 2 — Backend contract + wiring**
-- Define/adjust endpoints: `GET month` (raw expenses + subs + config),
-  `POST add/edit expense`, `DELETE expense`, `GET subscriptions`.
-- Replace localStorage reads/writes with API calls; keep localStorage as an
-  offline cache. Loading/error states per existing UX patterns.
+**Phase 2 — Backend contract + wiring** ✅ *(done — PR #11)*
+- [x] Define endpoints (contract in `data/api.js` + `.env.example`): `GET month`
+  (**padded ±7-day window** of expenses + subs + config), `POST add` / `PUT
+  update` / `POST delete` expense, `POST set-subscription-payment`. Subs ship
+  inside `GET month` (catalog CRUD is Phase 4). Backend not built yet — frontend
+  runs on an in-repo mock adapter until real URLs are set (§12 #7).
+- [x] Replace localStorage reads/writes with API calls (`data/api.js`, mock/real
+  by env flag); localStorage kept as the offline cache (`_stale` fallback).
+  Loading / error+retry / offline-notice states added. Budget config now
+  server-provided (§7.4/§12 #4).
+- Known follow-up (nit): in real mode, a successful write then a failed reload
+  shows cached data without the just-written row — revisit when the backend lands.
 
 **Phase 3 — Data migration + cutover**
 - Apply the category mapping to existing records (or read-time map).

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,20 +1,21 @@
 // ============================================================
-// v2 Amplop — top-level app: state, month nav, sheet routing, persistence.
-// Ported from amplop-app.jsx. Changes from the prototype:
-//  - Tweaks panel dropped; entry style is fixed to the "menu" FAB flow.
-//  - Pinned TODAY replaced with the real clock (lib/today.js).
-//  - AI scan flow deferred to Phase 5; the menu's Import option is stubbed.
-//  - localStorage via data/store.js (Phase 2 swaps in the API).
+// v2 Amplop — top-level app: state, month nav, sheet routing.
+//
+// Phase 2: data now flows through data/api.js (mock or real, env-selected)
+// instead of synchronous localStorage. The view loads a month at a time with
+// loading / error / retry states; budget config comes from the API response.
+// localStorage remains the offline cache (handled inside data/api.js).
 // ============================================================
 
-import { useEffect, useState } from 'react'
-import { MONTHS_ID, keyToDate } from './lib/dates.js'
+import { useCallback, useEffect, useState } from 'react'
+import { MONTHS_ID, keyToDate, monthPrefixOf } from './lib/dates.js'
 import { fmtK } from './lib/format.js'
 import { now, todayKey } from './lib/today.js'
-import { CFG, budgetConfig } from './lib/config.js'
+import { CFG } from './lib/config.js'
 import { CATS, catColor, envColor, tagOf } from './lib/categories.js'
 import { computeAmplop } from './lib/amplop-engine.js'
-import { loadStore, saveStore, buildByDay } from './data/store.js'
+import { buildByDay } from './data/store.js'
+import * as api from './data/api.js'
 
 import { EnvelopeCard } from './components/EnvelopeCard.jsx'
 import { AmplopCalendar } from './components/AmplopCalendar.jsx'
@@ -28,17 +29,50 @@ import { ScanEntryMenu } from './components/ScanEntryMenu.jsx'
 const TAG_STYLE = 'Garis samping'
 
 export function App() {
-  const [store, setStore] = useState(loadStore)
   const [cursor, setCursor] = useState(() => ({ y: now().getFullYear(), m: now().getMonth() }))
+  const [data, setData] = useState(null)   // { expenses, subs, config }
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [notice, setNotice] = useState(null)
   const [sheet, setSheet] = useState(null)
   const [filter, setFilter] = useState('Semua')
 
-  useEffect(() => { saveStore(store) }, [store])
-
   const y = cursor.y, m = cursor.m
-  const cfg = budgetConfig()
-  const A = computeAmplop(store.expenses, store.subs, y, m, cfg)
-  const byDay = buildByDay(store.expenses, store.subs, A.monthPrefix)
+  const monthPrefix = monthPrefixOf(y, m)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const d = await api.getMonth(y, m)
+      setData(d)
+      setNotice(d._stale ? 'Menampilkan data tersimpan (offline).' : null)
+    } catch (err) {
+      setError(err.message || 'Gagal memuat data.')
+    } finally {
+      setLoading(false)
+    }
+  }, [y, m])
+
+  useEffect(() => { load() }, [load])
+
+  // Re-fetch the current month after a successful write so the view stays true.
+  async function reload() {
+    try { setData(await api.getMonth(y, m)) } catch { /* keep current view */ }
+  }
+  async function runWrite(fn, closer) {
+    try {
+      await fn()
+      if (closer) closer()
+      await reload()
+    } catch (err) {
+      setNotice(err.message || 'Gagal menyimpan.')
+    }
+  }
+
+  const cfg = data && data.config
+  const A = data ? computeAmplop(data.expenses, data.subs, y, m, cfg) : null
+  const byDay = data ? buildByDay(data.expenses, data.subs, monthPrefix) : {}
   const spentOf = (k) => (byDay[k] || []).reduce((s, e) => s + e.amount, 0)
 
   const dayContext = (k) => {
@@ -71,30 +105,18 @@ export function App() {
       return { y: d.getFullYear(), m: d.getMonth() }
     })
   }
-  // FAB opens the entry menu (import / manual); a day cell goes straight to manual.
   function openAdd(k, from) {
-    if (from !== 'day') {
-      setSheet({ type: 'menu', k: k || todayKey(), from: from || null })
-    } else {
-      setSheet({ type: 'form', k: k || todayKey(), exp: null, from: from || null })
-    }
+    if (from !== 'day') setSheet({ type: 'menu', k: k || todayKey(), from: from || null })
+    else setSheet({ type: 'form', k: k || todayKey(), exp: null, from: from || null })
   }
-  function saveExpense(data) {
-    setStore((s) => {
-      if (data.id) {
-        return { ...s, expenses: s.expenses.map((e) => (e.id === data.id ? data : e)) }
-      }
-      return { ...s, expenses: s.expenses.concat([{ ...data, id: 'e' + Date.now() }]) }
-    })
-    closeForm()
+  function saveExpense(dataIn) {
+    runWrite(() => (dataIn.id ? api.updateExpense(dataIn) : api.addExpense(dataIn)), closeForm)
   }
   function deleteExpense(id) {
-    setStore((s) => ({ ...s, expenses: s.expenses.filter((e) => e.id !== id) }))
-    closeForm()
+    runWrite(() => api.deleteExpense(id), closeForm)
   }
   function setSubPaid(id, paid) {
-    setStore((s) => ({ ...s, subs: s.subs.map((x) => (x.id === id ? { ...x, paid } : x)) }))
-    closePay()
+    runWrite(() => api.setSubPayment(id, paid), closePay)
   }
   function closeForm() {
     setSheet((sh) => (sh && sh.from === 'day' ? { type: 'day', k: sh.k } : null))
@@ -113,8 +135,8 @@ export function App() {
 
   // ---------- Render ----------
   const cssVars = { '--accent': CFG.accent, '--cellH': CFG.cellH + 'px' }
-  const activeSub = sheet && sheet.type === 'pay'
-    ? store.subs.find((x) => x.id === sheet.subId)
+  const activeSub = sheet && sheet.type === 'pay' && data
+    ? data.subs.find((x) => x.id === sheet.subId)
     : null
 
   return (
@@ -134,20 +156,39 @@ export function App() {
         ) : null}
       </div>
 
-      <EnvelopeCard A={A} monthly={CFG.monthly} envColor={envColor}
-        onTapRow={(id) => setSheet({ type: 'env', which: id })} />
+      {notice ? (
+        <button className="notice" onClick={() => setNotice(null)}>{notice} <span className="notice-x">✕</span></button>
+      ) : null}
 
-      <AmplopCalendar y={y} m={m} spentOf={spentOf} cellH={CFG.cellH}
-        onDayTap={(k) => setSheet({ type: 'day', k })} />
+      {!data && loading ? (
+        <div className="state-card card"><div className="empty-note">Memuat data…</div></div>
+      ) : null}
 
-      <ListSection byDay={byDay} filter={filter} setFilter={setFilter} catColor={catColor}
-        cats={CATS.concat(['Langganan'])} tagOf={tagOf} tagStyle={TAG_STYLE}
-        onRowTap={(e) => openExpense(e, null, null)} />
+      {!data && error ? (
+        <div className="state-card card">
+          <div className="empty-note">{error}</div>
+          <button className="btn primary state-retry" onClick={load}>Coba lagi</button>
+        </div>
+      ) : null}
+
+      {data ? (
+        <>
+          <EnvelopeCard A={A} monthly={cfg.monthly} envColor={envColor}
+            onTapRow={(id) => setSheet({ type: 'env', which: id })} />
+
+          <AmplopCalendar y={y} m={m} spentOf={spentOf} cellH={CFG.cellH}
+            onDayTap={(k) => setSheet({ type: 'day', k })} />
+
+          <ListSection byDay={byDay} filter={filter} setFilter={setFilter} catColor={catColor}
+            cats={CATS.concat(['Langganan'])} tagOf={tagOf} tagStyle={TAG_STYLE}
+            onRowTap={(e) => openExpense(e, null, null)} />
+        </>
+      ) : null}
 
       <button className="fab" aria-label="Tambah pengeluaran hari ini"
         onClick={() => openAdd(todayKey(), null)}>+</button>
 
-      {sheet && sheet.type === 'day' ? (
+      {data && sheet && sheet.type === 'day' ? (
         <DaySheet k={sheet.k} list={byDay[sheet.k] || []}
           subLine={dayContext(sheet.k)} minis={dayMinis(sheet.k)} catColor={catColor}
           tagOf={tagOf} tagStyle={TAG_STYLE}
@@ -167,14 +208,14 @@ export function App() {
           onSave={saveExpense} onDelete={deleteExpense} onClose={closeForm} />
       ) : null}
 
-      {sheet && sheet.type === 'env' ? (
-        <EnvelopeSheet which={sheet.which} A={A} cfg={cfg} subs={store.subs}
+      {data && sheet && sheet.type === 'env' ? (
+        <EnvelopeSheet which={sheet.which} A={A} cfg={cfg} subs={data.subs}
           onTapSub={(sub) => setSheet({ type: 'pay', subId: sub.id, from: 'env' })}
           onClose={() => setSheet(null)} />
       ) : null}
 
       {activeSub ? (
-        <PaySheet sub={activeSub} monthPrefix={A.monthPrefix}
+        <PaySheet sub={activeSub} monthPrefix={monthPrefix}
           onSave={(paid) => setSubPaid(activeSub.id, paid)}
           onCancelPaid={() => setSubPaid(activeSub.id, null)}
           onClose={closePay} />

--- a/src/app.test.jsx
+++ b/src/app.test.jsx
@@ -3,19 +3,22 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { App } from './app.jsx'
 import { setNow } from './lib/today.js'
+import { _resetLocal } from './data/api.js'
 
 // Pin the clock to the seed month so the shell opens on data, deterministically.
 beforeEach(() => {
   setNow(() => new Date(2026, 5, 25, 12, 0, 0))
   if (typeof localStorage !== 'undefined') localStorage.clear()
+  _resetLocal()
 })
 afterEach(() => { setNow(null); cleanup() })
 
 describe('App — v2 shell mounts and renders', () => {
-  it('renders the current month title and envelope summary', () => {
+  it('renders the current month title and (after async load) the envelope summary', async () => {
     render(<App />)
-    expect(screen.getByText('Juni 2026')).toBeTruthy()
-    expect(screen.getByText('Terpakai')).toBeTruthy()
+    expect(screen.getByText('Juni 2026')).toBeTruthy() // topbar renders immediately
+    // Envelope card appears once the month data resolves from the API layer.
+    expect(await screen.findByText('Terpakai')).toBeTruthy()
     expect(screen.getByText('Budget')).toBeTruthy()
     expect(screen.getByText('Sisa')).toBeTruthy()
   })
@@ -28,10 +31,25 @@ describe('App — v2 shell mounts and renders', () => {
     expect(screen.getByText('Impor dari images')).toBeTruthy()
   })
 
-  it('navigates months and shows the "back to today" pill', () => {
+  it('navigates months and shows the "back to today" pill', async () => {
     render(<App />)
+    await screen.findByText('Terpakai')
     fireEvent.click(screen.getByLabelText('Bulan sebelumnya'))
     expect(screen.getByText('Mei 2026')).toBeTruthy()
     expect(screen.getByText('Kembali ke hari ini')).toBeTruthy()
+  })
+
+  it('adds an expense through the form and persists it (round-trip via the API)', async () => {
+    render(<App />)
+    // June seed = 26 expenses + 2 paid subs surfaced as rows = 28 transaksi.
+    expect(await screen.findByText(/28 transaksi/)).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Tambah pengeluaran hari ini'))
+    fireEvent.click(screen.getByText('Input manual'))
+    fireEvent.change(screen.getByPlaceholderText('0'), { target: { value: '50000' } })
+    fireEvent.click(screen.getByText('Simpan'))
+
+    // After the write + reload, the history count reflects the new expense.
+    expect(await screen.findByText(/29 transaksi/)).toBeTruthy()
   })
 })

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -1,0 +1,179 @@
+// ============================================================
+// v2 Amplop — data API layer (Phase 2).
+//
+// The real backend (separate Cloud Run services, not in this repo) does not yet
+// expose the v2 contract, so this module ships TWO adapters selected by env:
+//
+//   - mock  (default, when VITE_GET_MONTH_URL is unset): served from the
+//           localStorage store (data/store.js), seeded on first run. Lets the
+//           frontend run end-to-end offline.
+//   - real  (when the v2 URLs are configured): fetch() with a timeout, and the
+//           localStorage store kept as an offline cache (returned, flagged
+//           `_stale`, when a request fails after we've cached at least once).
+//
+// CONTRACT the backend must implement (so the real adapter just works):
+//
+//   GET  {VITE_GET_MONTH_URL}?month=YYYY-MM
+//        -> { expenses: Expense[], subs: Subscription[],
+//             config: { monthly, shopWeekly, weekendBudget } }
+//        IMPORTANT: `expenses` must be the PADDED window (±7 days) around the
+//        month, not just date-string matches — the envelope weeks/weekends
+//        cross month boundaries (see lib/dates.monthWindow).
+//   POST {VITE_ADD_EXPENSE_URL}      body: Expense (no id)   -> created Expense
+//   PUT  {VITE_UPDATE_EXPENSE_URL}   body: Expense (with id) -> updated Expense
+//   DELETE-style POST {VITE_DELETE_EXPENSE_URL} body: { id } -> { id }
+//   POST {VITE_SET_SUB_PAYMENT_URL}  body: { subId, paid: {date,amount}|null }
+//        -> updated Subscription
+//
+// Auth: unauthenticated, matching today's public endpoints (auth is out of
+// scope per plan §13).
+// ============================================================
+
+import { loadStore, saveStore } from './store.js'
+import { budgetConfig } from '../lib/config.js'
+import { monthWindow, monthPrefixOf } from '../lib/dates.js'
+
+const env = import.meta.env
+const TIMEOUT = parseInt(env.VITE_API_TIMEOUT, 10) || 10000
+const URLS = {
+  month: env.VITE_GET_MONTH_URL,
+  addExpense: env.VITE_ADD_EXPENSE_URL,
+  updateExpense: env.VITE_UPDATE_EXPENSE_URL,
+  deleteExpense: env.VITE_DELETE_EXPENSE_URL,
+  setSubPayment: env.VITE_SET_SUB_PAYMENT_URL,
+}
+
+/** True when no real endpoint is configured — run entirely on the mock. */
+export const USE_MOCK = !URLS.month
+
+// ---------- Local store (mock DB in mock mode; offline cache in real mode) ----------
+let _db = null
+let _hasCache = false
+let _seq = 0
+
+function db() {
+  if (!_db) {
+    const s = loadStore()
+    _db = { expenses: s.expenses.slice(), subs: s.subs.slice(), config: s.config || budgetConfig() }
+  }
+  return _db
+}
+function persist() { saveStore(_db) }
+function genId() { return 'e' + Date.now() + '-' + (_seq++) }
+
+/** Reset in-memory state. Test hook only. */
+export function _resetLocal() { _db = null; _hasCache = false; _seq = 0 }
+
+function windowView(y, m) {
+  const { fromKey, toKey } = monthWindow(y, m)
+  const d = db()
+  return {
+    expenses: d.expenses.filter((e) => e.date >= fromKey && e.date <= toKey),
+    subs: d.subs.map((s) => ({ ...s })),
+    config: { ...d.config },
+  }
+}
+
+function applyAdd(e) {
+  const created = { ...e, id: e.id || genId() }
+  db().expenses.push(created)
+  persist()
+  return created
+}
+function applyUpdate(e) {
+  const d = db()
+  d.expenses = d.expenses.map((x) => (x.id === e.id ? { ...e } : x))
+  persist()
+  return e
+}
+function applyDelete(id) {
+  const d = db()
+  d.expenses = d.expenses.filter((x) => x.id !== id)
+  persist()
+  return { id }
+}
+function applySetSubPayment(subId, paid) {
+  const d = db()
+  d.subs = d.subs.map((s) => (s.id === subId ? { ...s, paid } : s))
+  persist()
+  return d.subs.find((s) => s.id === subId)
+}
+
+// ---------- Real-adapter helpers ----------
+function friendly(err) {
+  if (err && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+    return new Error('Waktu permintaan habis — coba lagi.')
+  }
+  if (err && /Failed to fetch/i.test(String(err.message))) {
+    return new Error('Tidak dapat terhubung ke server.')
+  }
+  return err instanceof Error ? err : new Error('Terjadi kesalahan jaringan.')
+}
+async function getJSON(url) {
+  const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT) })
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  return res.json()
+}
+async function sendJSON(url, method, body) {
+  const res = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(TIMEOUT),
+  })
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  return res.json().catch(() => ({}))
+}
+function normalizeMonth(data) {
+  return {
+    expenses: Array.isArray(data.expenses) ? data.expenses : [],
+    subs: Array.isArray(data.subs) ? data.subs : [],
+    config: data.config || budgetConfig(),
+  }
+}
+function cacheMonth(y, m, data) {
+  const { fromKey, toKey } = monthWindow(y, m)
+  const d = db()
+  d.expenses = d.expenses.filter((e) => e.date < fromKey || e.date > toKey).concat(data.expenses || [])
+  if (Array.isArray(data.subs)) d.subs = data.subs
+  if (data.config) d.config = data.config
+  persist()
+  _hasCache = true
+}
+
+// ---------- Public API ----------
+
+/** Load a month's data (padded window + subs + budget config). */
+export async function getMonth(y, m) {
+  if (USE_MOCK) return windowView(y, m)
+  const sep = URLS.month.includes('?') ? '&' : '?'
+  try {
+    const data = normalizeMonth(await getJSON(URLS.month + sep + 'month=' + monthPrefixOf(y, m)))
+    cacheMonth(y, m, data)
+    return data
+  } catch (err) {
+    if (_hasCache) return { ...windowView(y, m), _stale: true }
+    throw friendly(err)
+  }
+}
+
+export async function addExpense(e) {
+  if (USE_MOCK) return applyAdd(e)
+  const { id, ...body } = e // eslint-disable-line no-unused-vars
+  try { return await sendJSON(URLS.addExpense, 'POST', body) } catch (err) { throw friendly(err) }
+}
+
+export async function updateExpense(e) {
+  if (USE_MOCK) return applyUpdate(e)
+  try { return await sendJSON(URLS.updateExpense, 'PUT', e) } catch (err) { throw friendly(err) }
+}
+
+export async function deleteExpense(id) {
+  if (USE_MOCK) return applyDelete(id)
+  try { return await sendJSON(URLS.deleteExpense, 'POST', { id }) } catch (err) { throw friendly(err) }
+}
+
+export async function setSubPayment(subId, paid) {
+  if (USE_MOCK) return applySetSubPayment(subId, paid)
+  try { return await sendJSON(URLS.setSubPayment, 'POST', { subId, paid }) } catch (err) { throw friendly(err) }
+}

--- a/src/data/api.real.test.js
+++ b/src/data/api.real.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Exercises the REAL adapter (failure paths) by configuring a URL via env and
+// stubbing global.fetch. Each test imports api.js fresh so USE_MOCK is false.
+beforeEach(() => {
+  vi.resetModules()
+  vi.stubEnv('VITE_GET_MONTH_URL', 'https://example.test/month')
+})
+afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks() })
+
+describe('api real adapter — failure paths', () => {
+  it('throws a friendly Indonesian error on a cold network failure', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Failed to fetch'))
+    const api = await import('./api.js')
+    expect(api.USE_MOCK).toBe(false)
+    await expect(api.getMonth(2026, 5)).rejects.toThrow('Tidak dapat terhubung ke server.')
+  })
+
+  it('falls back to the offline cache (flagged _stale) after a prior success', async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          expenses: [{ id: 'a', date: '2026-06-10', time: '12:00', amount: 5000, cat: 'Makan', note: '' }],
+          subs: [],
+          config: { monthly: 1, shopWeekly: 1, weekendBudget: 1 },
+        }),
+      })
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+    const api = await import('./api.js')
+
+    const fresh = await api.getMonth(2026, 5)
+    expect(fresh.expenses.some((e) => e.id === 'a')).toBe(true)
+
+    const stale = await api.getMonth(2026, 5)
+    expect(stale._stale).toBe(true)
+    expect(stale.expenses.some((e) => e.id === 'a')).toBe(true)
+  })
+
+  it('maps a non-ok HTTP response to an error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) })
+    const api = await import('./api.js')
+    await expect(api.getMonth(2026, 5)).rejects.toThrow()
+  })
+})

--- a/src/data/api.test.js
+++ b/src/data/api.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getMonth, addExpense, updateExpense, deleteExpense, setSubPayment, _resetLocal, USE_MOCK } from './api.js'
+
+// These exercise the mock adapter (no real endpoints configured in tests).
+beforeEach(() => { _resetLocal() })
+
+describe('api mock adapter', () => {
+  it('runs in mock mode when no endpoint URL is configured', () => {
+    expect(USE_MOCK).toBe(true)
+  })
+
+  it('getMonth returns expenses, subs, and the budget config', async () => {
+    const d = await getMonth(2026, 5)
+    expect(d.config).toEqual({ monthly: 5000000, shopWeekly: 600000, weekendBudget: 200000 })
+    expect(d.subs.length).toBe(4)
+    expect(d.expenses.length).toBeGreaterThan(0)
+    // Seed is June 2026 — all within the June window.
+    expect(d.expenses.every((e) => e.date.startsWith('2026-06'))).toBe(true)
+  })
+
+  it('returns the PADDED window so boundary days appear in the adjacent month', async () => {
+    // A Monday whose shopping week (Mon 06-29 .. Sun 07-05) belongs to July.
+    await addExpense({ date: '2026-06-29', time: '10:00', amount: 100000, cat: 'Belanja', note: 'x' })
+    const july = await getMonth(2026, 6)
+    expect(july.expenses.some((e) => e.date === '2026-06-29')).toBe(true)
+  })
+
+  it('addExpense assigns an id and persists', async () => {
+    const created = await addExpense({ date: '2026-06-20', time: '12:00', amount: 12345, cat: 'Makan', note: '' })
+    expect(created.id).toBeTruthy()
+    const d = await getMonth(2026, 5)
+    expect(d.expenses.find((e) => e.id === created.id).amount).toBe(12345)
+  })
+
+  it('updateExpense edits in place', async () => {
+    const created = await addExpense({ date: '2026-06-20', time: '12:00', amount: 100, cat: 'Makan', note: '' })
+    await updateExpense({ ...created, amount: 999 })
+    const d = await getMonth(2026, 5)
+    expect(d.expenses.find((e) => e.id === created.id).amount).toBe(999)
+  })
+
+  it('deleteExpense removes the row', async () => {
+    const created = await addExpense({ date: '2026-06-20', time: '12:00', amount: 100, cat: 'Makan', note: '' })
+    await deleteExpense(created.id)
+    const d = await getMonth(2026, 5)
+    expect(d.expenses.find((e) => e.id === created.id)).toBeUndefined()
+  })
+
+  it('setSubPayment sets and clears a subscription payment', async () => {
+    await setSubPayment('s3', { date: '2026-06-18', amount: 59000 })
+    let d = await getMonth(2026, 5)
+    expect(d.subs.find((s) => s.id === 's3').paid).toEqual({ date: '2026-06-18', amount: 59000 })
+
+    await setSubPayment('s3', null)
+    d = await getMonth(2026, 5)
+    expect(d.subs.find((s) => s.id === 's3').paid).toBeNull()
+  })
+})

--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -22,6 +22,28 @@ export function isWeekendKey(k) {
   return dow === 0 || dow === 6
 }
 
+/** 'YYYY-MM' prefix for a year + zero-based month. */
+export function monthPrefixOf(y, m) { return y + '-' + pad2(m + 1) }
+
+/**
+ * Inclusive date-key window covering a month plus padding on each side. The
+ * envelope engine's shopping weeks (Mon–Sun) and weekends (Sat–Sun) can spill
+ * a few days into the adjacent months, so `GET month` must return this padded
+ * window — not just date-string matches — or boundary spend is lost. 7 days
+ * each side is provably enough (a first Friday on the 1st has its Monday on the
+ * prev month's 27th; a last Saturday on the 31st has its Sunday on the 1st).
+ */
+export function monthWindow(y, m, padDays = 7) {
+  const start = new Date(y, m, 1)
+  start.setDate(start.getDate() - padDays)
+  const end = new Date(y, m + 1, 0)
+  end.setDate(end.getDate() + padDays)
+  return {
+    fromKey: dateKey(start.getFullYear(), start.getMonth(), start.getDate()),
+    toKey: dateKey(end.getFullYear(), end.getMonth(), end.getDate()),
+  }
+}
+
 // Month grid, one row per week, Monday-start. null = empty cell.
 export function monthGrid(y, m) {
   const lead = (new Date(y, m, 1).getDay() + 6) % 7

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -750,3 +750,30 @@ button { font-family: inherit; }
 .sb-t { font-size: 14.5px; font-weight: 700; }
 .sb-s { font-size: 11.5px; opacity: 0.85; font-weight: 500; }
 .sb-go { font-size: 22px; font-weight: 700; opacity: 0.8; }
+
+/* ---------- v2 Phase 2: load / error / offline states ---------- */
+.state-card {
+    margin: 14px;
+    padding: 28px 18px;
+    text-align: center;
+}
+.state-retry {
+    flex: 0 0 auto;
+    max-width: 200px;
+    margin: 6px auto 0;
+}
+.notice {
+    display: block;
+    width: calc(100% - 28px);
+    margin: 12px 14px 0;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    background: var(--red-bg);
+    color: var(--red);
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 9px 12px;
+    border-radius: 10px;
+}
+.notice-x { float: right; opacity: 0.7; }


### PR DESCRIPTION
## Intent

Phase 2 of the v2 **Amplop** redesign (`docs/v2-amplop-redesign-plan.md` §8): put a real data-API seam under the v2 shell so it loads/saves through endpoints, with localStorage demoted to an offline cache and proper loading/error states.

The v2 backend (separate Cloud Run services, not in this repo) **doesn't expose the v2 contract yet**, so per the plan's own guidance (§12 #7, §14) this defines the contract and ships a **mock adapter** to keep the frontend unblocked — flip to the real backend by setting env URLs.

## What's in it

- **`src/data/api.js`** — `getMonth / addExpense / updateExpense / deleteExpense / setSubPayment`.
  - **Mock mode** (default, when `VITE_GET_MONTH_URL` is unset): served from the localStorage store + seed; lets the app run end-to-end offline.
  - **Real mode**: `fetch` with `AbortSignal.timeout`, friendly Indonesian errors, and localStorage kept as an **offline cache** — returned flagged `_stale` on failure once we've cached at least one success.
- **Documented contract** for the backend, including the critical detail that `GET month` must return a **padded ±7-day window** (`lib/dates.monthWindow`), not just date-string matches — otherwise envelope weeks/weekends that straddle a month boundary lose their spend.
- **`src/app.jsx`** — per-month async load with **loading / error+retry / offline-notice** states; **budget config now comes from the API response** (§7.4/§12 #4), not the hard-coded `CFG`; writes go through the API and then re-fetch the month.
- **`.env.example`** documents all v1 + v2 env vars.

## Decisions applied (ratified this session)

- In-repo mock adapter behind an env flag (no new deps).
- Server-provided budget config in `GET month`.
- Persist expenses **and** subscription payment (the Phase 1 Bayar flow needs to survive a reload); full subscription CRUD remains Phase 4.
- Auth stays public (matches today's endpoints; §13).

## Test plan

`npm test` → **38 passing**:
- `api.test` — mock CRUD + the padded-window boundary case.
- `api.real.test` — real-adapter **failure paths**: cold network error → friendly message, offline-cache `_stale` fallback, non-ok HTTP.
- `app.test` — async load render + **write round-trip** (add expense → history count updates) + month nav.
- `format` / `amplop-engine` unchanged (24).

`npm run build` → green; v2 bundle + intact `index.html` app.

## Not in scope

Real endpoints/backend implementation (owned outside this repo), data migration/cutover (Phase 3), subscription CRUD (Phase 4), scan (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)