### PR TITLE
feat: Phase 4 — settings page (budget + subscriptions) + Langganan payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A comprehensive expense tracking application with both weekly and monthly views.
 
+> **v2 "Amplop" (in progress).** The envelope-budgeting redesign is being built
+> alongside the current app (see `docs/v2-amplop-redesign-plan.md`). It mounts at
+> **`/v2.html`**, and its **hidden settings page** (budget config + subscriptions)
+> is **`/settings.html`** — there is intentionally no in-app link to it; reach it
+> by typing the URL. The v2 app talks to the `expense-functions` backend via
+> `VITE_API_BASE_URL` (default `http://localhost:8080`).
+
 ## Features
 
 ### 🗓️ Weekly Expense Tracking

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,72 +1,38 @@
-# Review — PR #12: Phase 3 wire v2 Amplop client to the real backend
+# Review — PR #13 `docs/expand-phase-4-settings`
 
-First review (fresh, supersedes the PR #11 record). Scope: re-point the v2
-"Amplop" client at the real `expense-functions` backend (localhost:8080), which
-computes all envelope/budget math server-side and returns a render-ready month
-dashboard. Client is now a thin renderer. Phase-2 mock/seed/store/engine were
-intentionally removed. Reviewed at HEAD 1eda60e.
+Documentation-only change to `docs/v2-amplop-redesign-plan.md` §8 (Phase 4).
+Reviewed for internal consistency + factual accuracy only (no code → no
+correctness/security/test criteria).
 
-Ratified decisions honored as not-bugs: wire+verify only (v2.html, index.html
-cutover deferred); localhost default base URL baked into the v2 bundle is
-expected; in-repo mock/seed/store/engine/PaySheet/monthWindow/CFG-budget removed;
-Langganan rows read-only (subscription mgmt + Langganan add is Phase 4).
+## Checks performed
+- Backend endpoints in Phase 4 (`GET/PUT /budget`, `GET/POST/PUT/DELETE
+  /subscriptions`, payment = `Langganan` expense once/month → 409, derived
+  paid status) — match the stated real backend. ACCURATE.
+- `settings.html` separate Vite-entry claim — matches `vite.config.js`
+  rollup inputs (`index.html`, `v2.html` both present + configured). ACCURATE.
+- Phase 4 internal consistency: paid status stated consistently as **derived
+  server-side**; no "both stored and derived" contradiction. CONSISTENT.
+- Phase 4 vs §4 gap table (line 150 `subscriptionId`, line 152 "derived paid
+  status") and Phase 3 (line 337-344, backend resolved server-side): ALIGNED.
+  Phase 4 follows the authoritative post-Phase-3 backend reality.
 
 ## Blocking
-
-_None._
+(none)
 
 ## Resolved
-
-_None (first review of this PR; prior PR #11 record superseded)._
+(none)
 
 ## Non-blocking (nits)
-
-- nit: `src/app.jsx:52-54` `reload()` (post-write refetch) drops the `_stale`
-  flag, so if the server write succeeds but the immediate refetch fails the user
-  sees stale offline data without the offline notice. No data loss (write already
-  committed server-side); cosmetic, and carried over from Phase 2.
-- nit: `src/components/EnvelopeSheet.jsx:74,103-105` dereferences
-  `envById.langganan/belanja/weekend.budget` with no guard. The contract
-  guarantees all four envelopes so this is safe today; a malformed/partial
-  dashboard would throw inside the sheet (not on the main screen). Awareness only.
-- nit: `src/data/api.js:38-46` `friendly()` rewrites any error whose message
-  matches `/Failed to fetch|NetworkError/i`. A server `{error}` string containing
-  those words would be masked. Pathological; server messages are Indonesian.
-
-## Verification
-
-- Month indexing consistent: cursor stores 0-based `m`; every server call is
-  `api.getMonth(y, m+1)` (`app.jsx:40,53`); display uses `MONTHS_ID[m]`; grid
-  uses 0-based `monthGrid(y,m)` and `monthGrid`'s own `m+1` in `dateKey`;
-  `isCurrentMonth` prefers server `period.is_current`, falls back to local
-  compare only before load. api.test.js:25 + app.test.jsx:62 assert 1-based wire.
-- Field names match the contract: `occurred_at` (ExpRow/ExpenseForm via `hhmm`),
-  `envelope.{id,label}` (ExpRow tag), week/weekend `state` past|current|future
-  (EnvelopeSheet WeekRow), `due_day`/`paid.{date,amount}`/`alloc`
-  (EnvelopeSheet subs), `calendar[].{date,dow,is_weekend,is_today,spent}`
-  (AmplopCalendar), `stats.{spent,budget,remaining}`, `flex.{budget,spent,left}`,
-  `belanja_weeks[].{monday,friday,sunday,left}`, `weekends[].{saturday,sunday,
-  left}`. No mismatches found.
-- Data-null gating sound: no read of `dash.*` before load. `dayMinis`/`dayContext`
-  read `dash.*` unguarded but only run inside the `{dash && sheet.type==='day'}`
-  render branch (`app.jsx:175`). Calendar/list/envelope blocks all behind `dash ?`.
-- Write-then-reload flow correct: `runWrite` awaits the write, closes the sheet,
-  then `reload()`s; errors surface via `notice`. Langganan/`subscription_id` rows
-  are blocked from the edit form (`app.jsx:116-119`) and ExpenseForm always sends
-  `subscription_id: null` — consistent with Phase-3 manual categories only.
-- 204 handling: `sendJSON` returns null on 204 and tolerates an empty/throwing
-  json body (api.test.js:53-61). Server `{error}` passthrough on non-2xx proven
-  (api.test.js:63-69); network failure → friendly Indonesian (api.test.js:71-75);
-  `_stale` offline cache after a prior success, keyed per (year,month) so no
-  cross-month bleed (api.test.js:77-93).
-- Failure-path coverage present: api error + offline-cache + 204; app add
-  round-trip re-reads the month (1→2 transaksi) and asserts the POST body.
-- `npm test` → 24 passing; `npm run build` → green (emits dist/v2.html + v2
-  bundle, dist/index.html intact). Legacy production app (index.html, main.js,
-  tabs/monthly/recap/modal/details/style.css) untouched — focused diff.
-- CLAUDE.md: UI copy Indonesian; currency via shared `fmtK`/`fmtRp`; no secrets
-  (localhost base URL is a public dev default, not a credential); conventional
-  `feat:` commit; removed engine/mock cleanly with no dangling references.
-
-## Blocking issues
-_None._
+- nit: Budget-config field casing drift — §5.2 (line 197) / §7.4 (line 294)
+  use `shopWeekly` / `weekendBudget`; Phase 4 (line 363) uses `shop_weekly` /
+  `weekend_budget`. Same payload, different casing. Pick one across the doc.
+- nit: `subscriptionId` (§4 line 150, §7.1 line 260) vs `subscription_id`
+  (Phase 4 line 374) casing drift.
+- nit: Prototype sections §2.2 (line 91-98) and §7.3 (line 286-290) still
+  assert paid is **stored, not derived** and "no manual `Langganan` category."
+  Phase 4 (correctly, per the real backend) reverses both. This contradiction
+  is **pre-existing** (already present between §2.2 and the §4 gap table /
+  Phase 3 before this PR) and not introduced by this PR; the doc flags the
+  prototype-vs-backend layering at line 321-322 / 339. Worth a follow-up pass
+  to mark §2.2/§7.3 as superseded by the server-side backend, but out of scope
+  for this PR.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,38 +1,45 @@
-# Review — PR #13 `docs/expand-phase-4-settings`
+# Review — PR #14 `claude/expense-app-redesign-plan-phase-4-settings`
 
-Documentation-only change to `docs/v2-amplop-redesign-plan.md` §8 (Phase 4).
-Reviewed for internal consistency + factual accuracy only (no code → no
-correctness/security/test criteria).
+Phase 4 of the v2 "Amplop" redesign: hidden URL-only settings page (budget
+config + subscription catalog CRUD) and subscription payment via the normal
+add-expense form (Langganan category + picker; pay = POST Langganan expense;
+delete = un-pay). HEAD `2a57b5d`. First (full) review.
 
-## Checks performed
-- Backend endpoints in Phase 4 (`GET/PUT /budget`, `GET/POST/PUT/DELETE
-  /subscriptions`, payment = `Langganan` expense once/month → 409, derived
-  paid status) — match the stated real backend. ACCURATE.
-- `settings.html` separate Vite-entry claim — matches `vite.config.js`
-  rollup inputs (`index.html`, `v2.html` both present + configured). ACCURATE.
-- Phase 4 internal consistency: paid status stated consistently as **derived
-  server-side**; no "both stored and derived" contradiction. CONSISTENT.
-- Phase 4 vs §4 gap table (line 150 `subscriptionId`, line 152 "derived paid
-  status") and Phase 3 (line 337-344, backend resolved server-side): ALIGNED.
-  Phase 4 follows the authoritative post-Phase-3 backend reality.
+## Verification reproduced
+- `npm test` → 32 passing (4 files). Confirmed locally.
+- Backend contract / 1-based month / URL construction match tests + live notes.
 
 ## Blocking
-(none)
+- [x] Missing failure-path test for the new Langganan branch in
+  `src/components/ExpenseForm.jsx`. **Fixed:** `app.test.jsx` now has
+  "blocks a Langganan payment when no subscription is chosen" (asserts the
+  "Pilih langganan yang dibayar" error and that `addExpense` is NOT called).
+  Also added the budget reject-path test in `Settings.test.jsx`
+  ("rejects an invalid budget (negative)"). Suite: 34 passing.
 
 ## Resolved
-(none)
+- ExpenseForm Langganan no-sub-picked failure path — covered (app.test.jsx).
+- BudgetSection negative/non-integer rejection — covered (Settings.test.jsx).
 
 ## Non-blocking (nits)
-- nit: Budget-config field casing drift — §5.2 (line 197) / §7.4 (line 294)
-  use `shopWeekly` / `weekendBudget`; Phase 4 (line 363) uses `shop_weekly` /
-  `weekend_budget`. Same payload, different casing. Pick one across the doc.
-- nit: `subscriptionId` (§4 line 150, §7.1 line 260) vs `subscription_id`
-  (Phase 4 line 374) casing drift.
-- nit: Prototype sections §2.2 (line 91-98) and §7.3 (line 286-290) still
-  assert paid is **stored, not derived** and "no manual `Langganan` category."
-  Phase 4 (correctly, per the real backend) reverses both. This contradiction
-  is **pre-existing** (already present between §2.2 and the §4 gap table /
-  Phase 3 before this PR) and not introduced by this PR; the doc flags the
-  prototype-vs-backend layering at line 321-322 / 339. Worth a follow-up pass
-  to mark §2.2/§7.3 as superseded by the server-side backend, but out of scope
-  for this PR.
+- nit: `src/settings/Settings.jsx:41-49` — on a write error, `run()` sets the
+  notice but does not reload; the editor keeps optimistic local state. Harmless
+  (next load reconciles), but a reload-on-error would be tidier.
+- nit: `src/app.jsx:113` — `openExpense(e, from, k)` still takes an unused `k`
+  param (pre-existing).
+- nit: `src/data/api.js` — `getBudget`/`getSubscriptions` build query strings via
+  string concat (consistent with existing `getMonth`); fine, but `URLSearchParams`
+  would be uniform. Not a correctness issue (year/month are numbers).
+
+## Notes / things checked and found correct
+- ExpenseForm disable logic (`:85`): paid subs disabled except the currently
+  linked one when editing; `(initial && initial.subscription_id)` is `null` when
+  adding, so paid subs stay disabled. Correct.
+- `subscription_id` is sent iff category===Langganan, else `null` (`:32`). Correct.
+- 1-based month sent from Settings (`getMonth()+1`) and asserted in tests. Correct.
+- Old Langganan read-only guard removed cleanly in `app.jsx`; Langganan rows now
+  editable/deletable; EnvelopeSheet Langganan detail stays read-only. Correct.
+- api error passthrough incl. 409 covered (`api.test.js:63-69`); Settings
+  invalid-sub covered (`Settings.test.jsx:59-68`).
+- CLAUDE.md: Indonesian copy, currency via fmtRp/fmtK, no secrets, focused diff,
+  `index.html` (v1) untouched, settings is a separate Vite rollup input. OK.

--- a/docs/v2-amplop-redesign-plan.md
+++ b/docs/v2-amplop-redesign-plan.md
@@ -346,7 +346,7 @@ endpoint) instead of the hard-coded `CFG`. Required for §5.2.
   `VITE_API_BASE_URL` to it, replace `index.html`/tabs with the v2 app behind the
   same Firebase host. Deferred (separate, riskier step; backend is local-only).
 
-**Phase 4 — Settings: budget config + subscriptions management**
+**Phase 4 — Settings: budget config + subscriptions management** ✅ *(done — PR #14)*
 
 Scope expanded (this session): Phase 4 now covers **both** effective-dated config
 resources — budget config **and** the subscription catalog — because they are the

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>ShanCi Expense — Pengaturan</title>
+</head>
+<body>
+  <!-- Hidden settings page (budget config + subscriptions). URL-only: there is
+       no link to this from the app; reach it by typing /settings.html. -->
+  <div id="root"></div>
+  <script type="module" src="/src/settings-main.jsx"></script>
+</body>
+</html>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -111,12 +111,8 @@ export function App() {
     setSheet((sh) => (sh && sh.from === 'day' ? { type: 'day', k: sh.k } : null))
   }
   function openExpense(e, from, k) {
-    // Langganan payments are managed via the subscription flow (Phase 4); their
-    // rows are read-only here.
-    if (e.category === 'Langganan' || e.subscription_id) {
-      setNotice('Pembayaran langganan dikelola di fase berikutnya.')
-      return
-    }
+    // All expenses (incl. Langganan payments) open in the form for edit/delete;
+    // deleting a Langganan expense is how you "un-pay" a subscription.
     setSheet({ type: 'form', k: e.date, exp: e, from })
   }
 
@@ -189,6 +185,7 @@ export function App() {
 
       {sheet && sheet.type === 'form' ? (
         <ExpenseForm initial={sheet.exp} dateK={sheet.k} catColor={catColor}
+          subs={dash ? (dash.subscriptions || []) : []}
           onSave={(body) => saveExpense(sheet.exp, body)}
           onDelete={deleteExpense} onClose={closeForm} />
       ) : null}

--- a/src/app.test.jsx
+++ b/src/app.test.jsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 
 // The app renders the server dashboard, so we mock the API client.
 vi.mock('./data/api.js', () => ({
@@ -14,7 +14,7 @@ import { App } from './app.jsx'
 import { setNow } from './lib/today.js'
 import * as api from './data/api.js'
 
-function makeDash(dayRows) {
+function makeDash(dayRows, subscriptions = []) {
   const days = {}
   dayRows.forEach((r) => { (days[r.date] = days[r.date] || []).push(r) })
   return {
@@ -31,7 +31,7 @@ function makeDash(dayRows) {
     flex: { budget: 1800000, spent: 0, left: 1800000 },
     calendar: [{ date: '2026-06-23', dow: 2, is_weekend: false, is_today: false, spent: 18000 }],
     days,
-    subscriptions: [],
+    subscriptions,
   }
 }
 
@@ -93,5 +93,23 @@ describe('App — renders the server dashboard', () => {
     expect(await screen.findByText(/2 transaksi/)).toBeTruthy()
     const body = api.addExpense.mock.calls[0][0]
     expect(body).toMatchObject({ amount: 50000, category: 'Makan', subscription_id: null })
+  })
+
+  it('pays a subscription via the Langganan category + picker', async () => {
+    api.getMonth.mockResolvedValue(makeDash([], [
+      { id: 's1', name: 'Netflix', color: '#c8403c', alloc: 187000, due_day: 5, paid: null, status: 'unpaid' },
+    ]))
+
+    render(<App />)
+    await screen.findByText('Terpakai')
+    fireEvent.click(screen.getByLabelText('Tambah pengeluaran hari ini'))
+    fireEvent.click(screen.getByText('Input manual'))
+    fireEvent.click(screen.getByText('Langganan'))
+    fireEvent.change(screen.getByPlaceholderText('0'), { target: { value: '186000' } })
+    fireEvent.change(screen.getByLabelText('Langganan'), { target: { value: 's1' } })
+    fireEvent.click(screen.getByText('Simpan'))
+
+    await waitFor(() => expect(api.addExpense).toHaveBeenCalled())
+    expect(api.addExpense.mock.calls[0][0]).toMatchObject({ amount: 186000, category: 'Langganan', subscription_id: 's1' })
   })
 })

--- a/src/app.test.jsx
+++ b/src/app.test.jsx
@@ -112,4 +112,22 @@ describe('App — renders the server dashboard', () => {
     await waitFor(() => expect(api.addExpense).toHaveBeenCalled())
     expect(api.addExpense.mock.calls[0][0]).toMatchObject({ amount: 186000, category: 'Langganan', subscription_id: 's1' })
   })
+
+  it('blocks a Langganan payment when no subscription is chosen', async () => {
+    api.getMonth.mockResolvedValue(makeDash([], [
+      { id: 's1', name: 'Netflix', color: '#c8403c', alloc: 187000, due_day: 5, paid: null, status: 'unpaid' },
+    ]))
+
+    render(<App />)
+    await screen.findByText('Terpakai')
+    fireEvent.click(screen.getByLabelText('Tambah pengeluaran hari ini'))
+    fireEvent.click(screen.getByText('Input manual'))
+    fireEvent.click(screen.getByText('Langganan'))
+    fireEvent.change(screen.getByPlaceholderText('0'), { target: { value: '186000' } })
+    // intentionally leave the subscription picker on "Pilih langganan…"
+    fireEvent.click(screen.getByText('Simpan'))
+
+    expect(screen.getByText(/Pilih langganan yang dibayar/)).toBeTruthy()
+    expect(api.addExpense).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/ExpenseForm.jsx
+++ b/src/components/ExpenseForm.jsx
@@ -8,9 +8,13 @@ import { CATS } from '../lib/categories.js'
 import { pad2 } from '../lib/dates.js'
 import { fmtDateLong, hhmm } from '../lib/format.js'
 
-export function ExpenseForm({ initial, dateK, catColor, onSave, onDelete, onClose, onScan }) {
+// `subs` is the month's resolved subscription set (from the dashboard); a
+// Langganan expense pays one of them. Already-paid subs are disabled (the
+// backend allows at most one payment per subscription per calendar month).
+export function ExpenseForm({ initial, dateK, catColor, onSave, onDelete, onClose, onScan, subs = [] }) {
   const [amount, setAmount] = useState(initial ? String(initial.amount) : '')
   const [cat, setCat] = useState(initial ? initial.category : 'Makan')
+  const [subId, setSubId] = useState(initial && initial.subscription_id ? initial.subscription_id : '')
   const [note, setNote] = useState(initial && initial.note ? initial.note : '')
   const [time, setTime] = useState(() => {
     if (initial && initial.occurred_at) return hhmm(initial.occurred_at) || '00:00'
@@ -19,12 +23,15 @@ export function ExpenseForm({ initial, dateK, catColor, onSave, onDelete, onClos
   })
   const [err, setErr] = useState('')
 
+  const chips = CATS.concat(['Langganan'])
+
   function submit() {
     const a = parseInt(amount, 10)
     if (!a || a <= 0) { setErr('Masukkan jumlah yang valid'); return }
     if (!time) { setErr('Waktu wajib diisi'); return }
-    // Server body shape; subscription_id stays null (Langganan flow is Phase 4).
-    onSave({ date: dateK, time, amount: a, category: cat, subscription_id: null, note: note.trim() })
+    const sid = cat === 'Langganan' ? subId : null
+    if (cat === 'Langganan' && !sid) { setErr('Pilih langganan yang dibayar'); return }
+    onSave({ date: dateK, time, amount: a, category: cat, subscription_id: sid, note: note.trim() })
   }
 
   return (
@@ -53,18 +60,35 @@ export function ExpenseForm({ initial, dateK, catColor, onSave, onDelete, onClos
       </div>
       <label className="f-label">Kategori</label>
       <div className="cat-chips">
-        {CATS.map((c) => {
+        {chips.map((c) => {
           const on = c === cat
           return (
             <button key={c} className={'chip' + (on ? ' on' : '')}
               style={on ? { background: catColor(c) } : null}
-              onClick={() => setCat(c)}>
+              onClick={() => { setCat(c); setErr('') }}>
               <span className="dot" style={{ background: on ? 'rgba(255,255,255,.85)' : catColor(c) }}></span>
               {c}
             </button>
           )
         })}
       </div>
+      {cat === 'Langganan' ? (
+        <>
+          <label className="f-label">Langganan</label>
+          {subs.length === 0 ? (
+            <div className="form-err">Belum ada langganan. Tambahkan di halaman Pengaturan dulu.</div>
+          ) : (
+            <select className="f-in" aria-label="Langganan" value={subId}
+              onChange={(e) => { setSubId(e.target.value); setErr('') }}>
+              <option value="">Pilih langganan…</option>
+              {subs.map((s) => {
+                const paid = s.status === 'paid' && s.id !== (initial && initial.subscription_id)
+                return <option key={s.id} value={s.id} disabled={paid}>{s.name}{paid ? ' (sudah dibayar)' : ''}</option>
+              })}
+            </select>
+          )}
+        </>
+      ) : null}
       <div className="form-row">
         <div className="form-col">
           <label className="f-label">Waktu</label>

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -94,3 +94,25 @@ export async function updateExpense(id, body) {
 export async function deleteExpense(id) {
   try { return await sendJSON(BASE + '/expenses/' + encodeURIComponent(id), 'DELETE') } catch (err) { throw friendly(err) }
 }
+
+// ---------- budget config (effective-dated; PUT applies from current month) ----------
+export async function getBudget(year, month) {
+  try { return await getJSON(BASE + '/budget?year=' + year + '&month=' + month) } catch (err) { throw friendly(err) }
+}
+export async function putBudget(body) {
+  try { return await sendJSON(BASE + '/budget', 'PUT', body) } catch (err) { throw friendly(err) }
+}
+
+// ---------- subscription catalog (definitions; paid status lives in /month) ----------
+export async function getSubscriptions(year, month) {
+  try { return await getJSON(BASE + '/subscriptions?year=' + year + '&month=' + month) } catch (err) { throw friendly(err) }
+}
+export async function createSubscription(body) {
+  try { return await sendJSON(BASE + '/subscriptions', 'POST', body) } catch (err) { throw friendly(err) }
+}
+export async function updateSubscription(id, body) {
+  try { return await sendJSON(BASE + '/subscriptions/' + encodeURIComponent(id), 'PUT', body) } catch (err) { throw friendly(err) }
+}
+export async function deleteSubscription(id) {
+  try { return await sendJSON(BASE + '/subscriptions/' + encodeURIComponent(id), 'DELETE') } catch (err) { throw friendly(err) }
+}

--- a/src/data/api.test.js
+++ b/src/data/api.test.js
@@ -91,4 +91,40 @@ describe('api client', () => {
     expect(stale._stale).toBe(true)
     expect(stale.period).toEqual(MINI_DASH.period)
   })
+
+  it('getBudget / putBudget hit /budget', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonRes({ monthly: 5000000, shop_weekly: 600000, weekend_budget: 200000 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const api = await import('./api.js')
+
+    await api.getBudget(2026, 6)
+    expect(fetchMock).toHaveBeenCalledWith('http://test.local/budget?year=2026&month=6', expect.any(Object))
+
+    await api.putBudget({ monthly: 5500000, shop_weekly: 650000, weekend_budget: 200000 })
+    const [url, opts] = fetchMock.mock.calls[1]
+    expect(url).toBe('http://test.local/budget')
+    expect(opts.method).toBe('PUT')
+    expect(JSON.parse(opts.body)).toMatchObject({ monthly: 5500000 })
+  })
+
+  it('subscription CRUD hits /subscriptions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonRes({ id: 's1' }))
+    vi.stubGlobal('fetch', fetchMock)
+    const api = await import('./api.js')
+
+    await api.getSubscriptions(2026, 6)
+    expect(fetchMock.mock.calls[0][0]).toBe('http://test.local/subscriptions?year=2026&month=6')
+
+    await api.createSubscription({ name: 'Netflix', color: '#c8403c', alloc: 187000, due_day: 5 })
+    expect(fetchMock.mock.calls[1][0]).toBe('http://test.local/subscriptions')
+    expect(fetchMock.mock.calls[1][1].method).toBe('POST')
+
+    await api.updateSubscription('s1', { alloc: 200000 })
+    expect(fetchMock.mock.calls[2][0]).toBe('http://test.local/subscriptions/s1')
+    expect(fetchMock.mock.calls[2][1].method).toBe('PUT')
+
+    await api.deleteSubscription('s1')
+    expect(fetchMock.mock.calls[3][0]).toBe('http://test.local/subscriptions/s1')
+    expect(fetchMock.mock.calls[3][1].method).toBe('DELETE')
+  })
 })

--- a/src/settings-main.jsx
+++ b/src/settings-main.jsx
@@ -1,0 +1,12 @@
+// React entry for the hidden Pengaturan (settings) page. Mounted from settings.html.
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Settings } from './settings/Settings.jsx'
+import './styles/tokens.css'
+import './styles/app.css'
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <Settings />
+  </StrictMode>,
+)

--- a/src/settings/BudgetSection.jsx
+++ b/src/settings/BudgetSection.jsx
@@ -1,0 +1,49 @@
+// Budget config editor. Values are integer Rupiah; PUT applies from this month.
+
+import { useState } from 'react'
+
+const FIELDS = [
+  { key: 'monthly', label: 'Budget bulanan' },
+  { key: 'shop_weekly', label: 'Belanja mingguan (per Jumat)' },
+  { key: 'weekend_budget', label: 'Akhir pekan (per Sabtu–Minggu)' },
+]
+
+export function BudgetSection({ budget, onSave }) {
+  const [vals, setVals] = useState(() => ({
+    monthly: String(budget.monthly),
+    shop_weekly: String(budget.shop_weekly),
+    weekend_budget: String(budget.weekend_budget),
+  }))
+  const [err, setErr] = useState('')
+
+  function submit() {
+    const out = {}
+    for (const f of FIELDS) {
+      const n = parseInt(vals[f.key], 10)
+      if (!Number.isInteger(n) || n < 0) { setErr('Nilai harus angka ≥ 0'); return }
+      out[f.key] = n
+    }
+    setErr('')
+    onSave(out)
+  }
+
+  return (
+    <div className="card set-card">
+      <div className="set-sec-title">Budget</div>
+      {err ? <div className="form-err">⚠️ {err}</div> : null}
+      {FIELDS.map((f) => (
+        <div key={f.key}>
+          <label className="f-label">{f.label}</label>
+          <div className="amt-wrap">
+            <span className="amt-rp">Rp</span>
+            <input className="amt-in" type="number" inputMode="numeric" step="1000" min="0"
+              aria-label={f.label}
+              value={vals[f.key]}
+              onChange={(e) => { setVals((v) => ({ ...v, [f.key]: e.target.value })); setErr('') }} />
+          </div>
+        </div>
+      ))}
+      <button className="btn primary full set-save" onClick={submit}>Simpan budget</button>
+    </div>
+  )
+}

--- a/src/settings/Settings.jsx
+++ b/src/settings/Settings.jsx
@@ -1,0 +1,98 @@
+// ============================================================
+// Pengaturan (Settings) — budget config + subscription catalog.
+// Both are effective-dated config: edits apply from the CURRENT month
+// (past months frozen) — the backend enforces this; the UI says so.
+// ============================================================
+
+import { useCallback, useEffect, useState } from 'react'
+import { now } from '../lib/today.js'
+import { CFG } from '../lib/config.js'
+import { fmtRp } from '../lib/format.js'
+import * as api from '../data/api.js'
+import { BudgetSection } from './BudgetSection.jsx'
+import { SubscriptionsSection } from './SubscriptionsSection.jsx'
+
+export function Settings() {
+  const y = now().getFullYear()
+  const month = now().getMonth() + 1 // backend months are 1-based
+
+  const [budget, setBudget] = useState(null)
+  const [subs, setSubs] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [notice, setNotice] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [b, s] = await Promise.all([api.getBudget(y, month), api.getSubscriptions(y, month)])
+      setBudget(b)
+      setSubs(s)
+    } catch (err) {
+      setError(err.message || 'Gagal memuat pengaturan.')
+    } finally {
+      setLoading(false)
+    }
+  }, [y, month])
+
+  useEffect(() => { load() }, [load])
+
+  async function run(fn, okMsg) {
+    try {
+      await fn()
+      setNotice(okMsg)
+      await load()
+    } catch (err) {
+      setNotice(err.message || 'Gagal menyimpan.')
+    }
+  }
+
+  const cssVars = { '--accent': CFG.accent }
+
+  return (
+    <div className="app settings" style={cssVars}>
+      <div className="set-top">
+        <a className="set-back" href="/v2.html">‹ Kembali</a>
+        <div className="set-title">Pengaturan</div>
+      </div>
+
+      {notice ? (
+        <button className="notice" onClick={() => setNotice(null)}>{notice} <span className="notice-x">✕</span></button>
+      ) : null}
+
+      {loading && !budget ? (
+        <div className="state-card card"><div className="empty-note">Memuat…</div></div>
+      ) : null}
+
+      {error && !budget ? (
+        <div className="state-card card">
+          <div className="empty-note">{error}</div>
+          <button className="btn primary state-retry" onClick={load}>Coba lagi</button>
+        </div>
+      ) : null}
+
+      {budget ? (
+        <BudgetSection
+          budget={budget}
+          onSave={(body) => run(() => api.putBudget(body), 'Budget tersimpan.')}
+        />
+      ) : null}
+
+      {subs ? (
+        <SubscriptionsSection
+          subs={subs}
+          fmtRp={fmtRp}
+          onCreate={(body) => run(() => api.createSubscription(body), 'Langganan ditambahkan.')}
+          onUpdate={(id, body) => run(() => api.updateSubscription(id, body), 'Langganan diperbarui.')}
+          onDelete={(id) => run(() => api.deleteSubscription(id), 'Langganan dihentikan.')}
+        />
+      ) : null}
+
+      <div className="set-foot">
+        Perubahan budget &amp; langganan berlaku mulai bulan ini; bulan-bulan
+        sebelumnya tidak berubah.
+      </div>
+    </div>
+  )
+}

--- a/src/settings/Settings.test.jsx
+++ b/src/settings/Settings.test.jsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('../data/api.js', () => ({
+  getBudget: vi.fn(),
+  putBudget: vi.fn(),
+  getSubscriptions: vi.fn(),
+  createSubscription: vi.fn(),
+  updateSubscription: vi.fn(),
+  deleteSubscription: vi.fn(),
+}))
+
+import { Settings } from './Settings.jsx'
+import { setNow } from '../lib/today.js'
+import * as api from '../data/api.js'
+
+beforeEach(() => {
+  setNow(() => new Date(2026, 5, 25, 12, 0, 0))
+  api.getBudget.mockResolvedValue({ effective_year: 2025, effective_month: 1, monthly: 5000000, shop_weekly: 600000, weekend_budget: 200000 })
+  api.getSubscriptions.mockResolvedValue([{ id: 's1', name: 'Netflix', color: '#c8403c', alloc: 187000, due_day: 5 }])
+  api.putBudget.mockResolvedValue({})
+  api.createSubscription.mockResolvedValue({ id: 's2' })
+  api.deleteSubscription.mockResolvedValue(null)
+})
+afterEach(() => { setNow(null); vi.clearAllMocks(); cleanup() })
+
+describe('Settings page', () => {
+  it('loads budget + subscriptions for the current month (1-based)', async () => {
+    render(<Settings />)
+    expect(await screen.findByText('Budget')).toBeTruthy()
+    expect(api.getBudget).toHaveBeenCalledWith(2026, 6)
+    expect(api.getSubscriptions).toHaveBeenCalledWith(2026, 6)
+    expect(screen.getByLabelText('Budget bulanan').value).toBe('5000000')
+    expect(screen.getByText('Netflix')).toBeTruthy()
+  })
+
+  it('saves edited budget via putBudget', async () => {
+    render(<Settings />)
+    await screen.findByText('Budget')
+    fireEvent.change(screen.getByLabelText('Budget bulanan'), { target: { value: '5500000' } })
+    fireEvent.click(screen.getByText('Simpan budget'))
+    await waitFor(() => expect(api.putBudget).toHaveBeenCalled())
+    expect(api.putBudget.mock.calls[0][0]).toMatchObject({ monthly: 5500000, shop_weekly: 600000, weekend_budget: 200000 })
+  })
+
+  it('creates a subscription', async () => {
+    render(<Settings />)
+    await screen.findByText('Langganan')
+    fireEvent.click(screen.getByText('+ Tambah langganan'))
+    fireEvent.change(screen.getByLabelText('Nama'), { target: { value: 'Spotify' } })
+    fireEvent.change(screen.getByLabelText('Alokasi'), { target: { value: '55000' } })
+    fireEvent.change(screen.getByLabelText('Jatuh tempo'), { target: { value: '10' } })
+    fireEvent.click(screen.getByText('Simpan'))
+    await waitFor(() => expect(api.createSubscription).toHaveBeenCalled())
+    expect(api.createSubscription.mock.calls[0][0]).toMatchObject({ name: 'Spotify', alloc: 55000, due_day: 10 })
+  })
+
+  it('rejects an invalid subscription (no name)', async () => {
+    render(<Settings />)
+    await screen.findByText('Langganan')
+    fireEvent.click(screen.getByText('+ Tambah langganan'))
+    fireEvent.change(screen.getByLabelText('Alokasi'), { target: { value: '55000' } })
+    fireEvent.change(screen.getByLabelText('Jatuh tempo'), { target: { value: '10' } })
+    fireEvent.click(screen.getByText('Simpan'))
+    expect(screen.getByText(/Nama wajib diisi/)).toBeTruthy()
+    expect(api.createSubscription).not.toHaveBeenCalled()
+  })
+
+  it('deletes a subscription', async () => {
+    render(<Settings />)
+    await screen.findByText('Netflix')
+    fireEvent.click(screen.getByText('Hapus'))
+    await waitFor(() => expect(api.deleteSubscription).toHaveBeenCalledWith('s1'))
+  })
+})

--- a/src/settings/Settings.test.jsx
+++ b/src/settings/Settings.test.jsx
@@ -44,6 +44,15 @@ describe('Settings page', () => {
     expect(api.putBudget.mock.calls[0][0]).toMatchObject({ monthly: 5500000, shop_weekly: 600000, weekend_budget: 200000 })
   })
 
+  it('rejects an invalid budget (negative) and does not call putBudget', async () => {
+    render(<Settings />)
+    await screen.findByText('Budget')
+    fireEvent.change(screen.getByLabelText('Budget bulanan'), { target: { value: '-5' } })
+    fireEvent.click(screen.getByText('Simpan budget'))
+    expect(screen.getByText(/Nilai harus angka/)).toBeTruthy()
+    expect(api.putBudget).not.toHaveBeenCalled()
+  })
+
   it('creates a subscription', async () => {
     render(<Settings />)
     await screen.findByText('Langganan')

--- a/src/settings/SubscriptionsSection.jsx
+++ b/src/settings/SubscriptionsSection.jsx
@@ -1,0 +1,94 @@
+// Subscription catalog CRUD (definitions only — paid status is a /month
+// concern). Edits to alloc/due_day version from the current month.
+
+import { useState } from 'react'
+
+const DEFAULT_COLOR = '#5b63d3'
+
+function SubForm({ initial, onSubmit, onCancel }) {
+  const [name, setName] = useState(initial ? initial.name : '')
+  const [color, setColor] = useState(initial ? initial.color || DEFAULT_COLOR : DEFAULT_COLOR)
+  const [alloc, setAlloc] = useState(initial ? String(initial.alloc) : '')
+  const [dueDay, setDueDay] = useState(initial ? String(initial.due_day) : '')
+  const [err, setErr] = useState('')
+
+  function submit() {
+    const a = parseInt(alloc, 10)
+    const d = parseInt(dueDay, 10)
+    if (!name.trim()) { setErr('Nama wajib diisi'); return }
+    if (!Number.isInteger(a) || a <= 0) { setErr('Alokasi harus angka > 0'); return }
+    if (!Number.isInteger(d) || d < 1 || d > 31) { setErr('Jatuh tempo harus 1–31'); return }
+    onSubmit({ name: name.trim(), color, alloc: a, due_day: d })
+  }
+
+  return (
+    <div className="sub-form">
+      {err ? <div className="form-err">⚠️ {err}</div> : null}
+      <label className="f-label">Nama</label>
+      <div className="sub-name-row">
+        <input className="f-in" type="color" aria-label="Warna" value={color} onChange={(e) => setColor(e.target.value)} />
+        <input className="f-in" type="text" placeholder="Netflix" aria-label="Nama" value={name}
+          onChange={(e) => { setName(e.target.value); setErr('') }} />
+      </div>
+      <div className="form-row">
+        <div className="form-col">
+          <label className="f-label">Alokasi</label>
+          <div className="amt-wrap">
+            <span className="amt-rp">Rp</span>
+            <input className="amt-in" type="number" inputMode="numeric" step="1000" min="1" aria-label="Alokasi"
+              value={alloc} onChange={(e) => { setAlloc(e.target.value); setErr('') }} />
+          </div>
+        </div>
+        <div className="form-col">
+          <label className="f-label">Jatuh tempo (tgl)</label>
+          <input className="f-in" type="number" inputMode="numeric" min="1" max="31" aria-label="Jatuh tempo"
+            value={dueDay} onChange={(e) => { setDueDay(e.target.value); setErr('') }} />
+        </div>
+      </div>
+      <div className="btn-row">
+        <button className="btn ghost" onClick={onCancel}>Batal</button>
+        <button className="btn primary" onClick={submit}>Simpan</button>
+      </div>
+    </div>
+  )
+}
+
+export function SubscriptionsSection({ subs, fmtRp, onCreate, onUpdate, onDelete }) {
+  const [editing, setEditing] = useState(null) // null | 'new' | sub id
+
+  return (
+    <div className="card set-card">
+      <div className="set-sec-title">Langganan</div>
+
+      {subs.length === 0 ? (
+        <div className="empty-note">Belum ada langganan</div>
+      ) : (
+        subs.map((s) => (
+          editing === s.id ? (
+            <SubForm key={s.id} initial={s}
+              onSubmit={(body) => { onUpdate(s.id, body); setEditing(null) }}
+              onCancel={() => setEditing(null)} />
+          ) : (
+            <div className="sub-row" key={s.id}>
+              <span className="cat-dot" style={{ background: s.color || DEFAULT_COLOR }}></span>
+              <span className="sub-main">
+                <span className="sub-name">{s.name}</span>
+                <span className="sub-sub">{fmtRp(s.alloc)} · jatuh tempo tgl {s.due_day}</span>
+              </span>
+              <span className="sub-acts">
+                <button className="link-btn" onClick={() => setEditing(s.id)}>Ubah</button>
+                <button className="link-btn danger" onClick={() => onDelete(s.id)}>Hapus</button>
+              </span>
+            </div>
+          )
+        ))
+      )}
+
+      {editing === 'new' ? (
+        <SubForm onSubmit={(body) => { onCreate(body); setEditing(null) }} onCancel={() => setEditing(null)} />
+      ) : (
+        <button className="btn ghost full set-add" onClick={() => setEditing('new')}>+ Tambah langganan</button>
+      )}
+    </div>
+  )
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -777,3 +777,34 @@ button { font-family: inherit; }
     border-radius: 10px;
 }
 .notice-x { float: right; opacity: 0.7; }
+
+/* ---------- Pengaturan (settings) page ---------- */
+.settings { padding-bottom: 40px; }
+.set-top {
+    background: linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 60%, #241c4a));
+    padding: 18px 16px 20px;
+    color: #fff;
+}
+.set-back {
+    display: inline-block;
+    color: #fff;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 700;
+    opacity: 0.9;
+}
+.set-title { font-size: 21px; font-weight: 700; margin-top: 6px; }
+.set-card { padding: 14px 16px 18px; }
+.set-sec-title { font-size: 15.5px; font-weight: 700; margin-bottom: 4px; }
+.set-save, .set-add { margin-top: 16px; }
+.set-foot {
+    margin: 14px;
+    font-size: 11.5px;
+    color: var(--muted);
+    line-height: 1.45;
+}
+.sub-acts { margin-left: auto; display: flex; gap: 12px; flex: none; }
+.link-btn.danger { color: var(--red); }
+.sub-form { border-top: 1px solid var(--line); margin-top: 8px; padding-top: 6px; }
+.sub-name-row { display: flex; gap: 8px; align-items: center; }
+.sub-name-row input[type="color"] { width: 44px; padding: 4px; flex: none; height: 40px; }

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,7 +19,10 @@ export default defineConfig({
         main: './index.html',
         // v2 "Amplop" shell — built alongside the live app until the Phase 3
         // cutover swaps index.html over to it.
-        v2: './v2.html'
+        v2: './v2.html',
+        // Hidden settings page (budget + subscriptions); URL-only, no link from
+        // the app. Reachable at /settings.html.
+        settings: './settings.html'
       }
     }
   },


### PR DESCRIPTION
## Intent

Phase 4 of the v2 **Amplop** redesign (`docs/v2-amplop-redesign-plan.md` §8): the two effective-dated **config** surfaces (budget + subscription catalog) on a hidden settings page, plus the **subscription-payment** flow. Built against the real backend.

## What's in it

**Hidden settings page — `settings.html` (URL-only, no in-app link):**
- **Budget editor** — `GET /budget` → edit `monthly` / `shop_weekly` / `weekend_budget` → `PUT /budget` (effective from the current month).
- **Subscription catalog CRUD** (definitions) — list / create / update / delete via `/subscriptions`.
- "← Kembali" link back to the app; effective-dating notice; loading/error/notice states.

**Subscription payment — in the normal add-expense flow** (the option chosen this session):
- `ExpenseForm` gains a **Langganan** category + **subscription picker** (required; already-paid subs disabled). Paying = `POST` a Langganan expense with `subscription_id`. The once-per-month **409** surfaces as a notice (backstop to the disabled options).
- Langganan expense rows are now **editable/deletable** (delete = "un-pay"). The Amplop envelope detail stays **read-only**.

**Plumbing:** `api.js` gets `getBudget`/`putBudget` + subscription CRUD; `vite.config.js` adds the `settings.html` entry; README documents the `/settings.html` URL.

## Decisions applied (ratified this session)

- Budget editing folded in **with** subscriptions on one hidden, URL-only page (separate Vite entry, no router).
- Payment lives in the **main add-expense form** (not a settings "Bayar" button); settings is definitions-only.
- Paid status stays **derived server-side**; settings operates on the **current month** (effective-dated).

## Verification

- **Live against localhost:8080**: `PUT /budget` (+restore to original), subscription create/update/delete, a Langganan payment (`/month` shows `status=paid`), and the **duplicate-payment 409** my picker/notice rely on. Dev DB restored.
- `npm test` → **32 passing** (api budget+subs calls; settings render + CRUD + validation failure path; form Langganan payment path; existing suites). `npm run build` → green (emits `settings.html` + bundle).

## Not in scope

Production cutover/deploy (deferred Phase 3 item); AI scan (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)